### PR TITLE
chore: remove campaign references

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -5,33 +5,23 @@ import { AuthGuardService } from './auth-guard.service';
 import { AppCustomPreloader } from './app-routing-loader';
 import { HomeComponent } from './core/home/home.component';
 import { ShareVideoComponent } from './videos/share-video/share-video.component';
-import { CampaignVideoComponent } from './videos/campaign-video/campaign-video.component';
 import { SocialLoginComponent } from './social/common/social-login/social-login.component';
 import { SocialCallbackComponent } from './social/common/social-callback/social-callback.component';
 import { ProfileLockComponent } from './dashboard/user-profile/profile-lock/profile-lock.component';
-import { LogEmailClickComponent } from './campaigns/log-email-click/log-email-click.component';
-import { LogUnsubscribeComponent } from './campaigns/log-unsubscribe/log-unsubscribe.component';
 import { ServiceUnavailableComponent } from './error-pages/service-unavailable/service-unavailable.component';
 import { PageNotFoundComponent } from './error-pages/page-not-found/page-not-found.component';
 import { ErrorPagesComponent } from './error-pages/error-pages/error-pages.component';
 import { AccessDeniedComponent } from './error-pages/access-denied/access-denied.component';
-import { LogRegularCampaignComponent } from './campaigns/log-regular-campaign/log-regular-campaign.component';
 import { LoginComponent } from './authentication/login/login.component';
 import { SignupComponent } from './authentication/signup/signup.component';
 import { ForgotPasswordComponent } from './authentication/forgot-password/forgot-password.component';
 import { VerifyEmailComponent } from './authentication/verify-email/verify-email.component';
 import { CompanyPageComponent } from './dashboard/company-profile/company-page/company-page.component';
 import { TermsConditonComponent } from 'app/authentication/terms-conditon/terms-conditon.component';
-import { RsvpComponent } from './campaigns/rsvp/rsvp.component';
-import { LogRegularCampaignComponentSMS } from './campaigns/log-regular-campaign-sms/log-regular-campaign-sms.component';
-import { CampaignSMSVideoComponent } from './videos/campaign-sms-video/campaign-sms-video.component';
-import { LogEventCampaignComponentSMS } from './campaigns/log-event-campaign-sms/log-event-campaign-sms.component';
-import { LogSMSClickComponent } from './campaigns/log-sms-click/log-sms-click.component';
 import { FormPreviewComponent } from './forms/preview/form-preview.component';
 import { ShowLandingPageComponent } from './landing-pages/show-landing-page/show-landing-page.component';
 import { RequestDemoComponent } from './authentication/request-demo/request-demo.component';
 import { AccessAccountComponent } from './authentication/access-account/access-account.component';
-import { DownloadTemplateComponent } from './campaigns/download-template/download-template.component';
 import { PublicPageResponseComponent } from 'app/common/public-page-response/public-page-response.component';
 import { SamlsecurityauthComponent } from './authentication/samlsecurityauth/samlsecurityauth.component';
 import { VanitySocialLoginComponent } from 'app/social/common/vanity-social-login/vanity-social-login.component';
@@ -50,9 +40,6 @@ import { PreviewAssetPdfComponent } from './common/preview-asset-pdf/preview-ass
 import { WelcomePageComponent } from './common/welcome-page/welcome-page.component';
 import { MarketplaceUtilComponent } from './util/marketplace-util/marketplace-util.component';
 import { MarketplaceMapUtilComponent } from './util/marketplace-map-util/marketplace-map-util.component';
-import { CampaignMdfAnalyticsComponent } from './campaigns/campaign-mdf-analytics/campaign-mdf-analytics.component';
-import { CampaignMdfTemplatePreviewComponent } from './campaigns/campaign-mdf-template-preview/campaign-mdf-template-preview.component';
-import { CampaignMdfSearchComponent } from './util/campaign-mdf-search/campaign-mdf-search.component';
 
 
 export const routes: Routes = [
@@ -98,7 +85,6 @@ export const routes: Routes = [
 			{ path: 'assignleads', loadChildren: 'app/contacts/contacts.module#ContactsModule', data: { preload: true } },
 			{ path: 'sharedleads', loadChildren: 'app/contacts/contacts.module#ContactsModule', data: { preload: true } },
 			{ path: 'partners', loadChildren: 'app/partners/partners.module#PartnersModule', data: { preload: true } },
-			{ path: 'campaigns', loadChildren: 'app/campaigns/campaigns.module#CampaignsModule', data: { preload: true } },
 			{ path: 'upgrade', loadChildren: 'app/upgrade/upgrade.module#UpgradeModule', data: { preload: true } },
 			{ path: 'team', loadChildren: 'app/team/team-member.module#TeamMemberModule', data: { preload: true } },
 			{ path: 'deals', loadChildren: 'app/deal-registration/deal-registration.module#DealRegistrationModule', data: { preload: true } },
@@ -139,20 +125,11 @@ export const routes: Routes = [
 	{ path: 'syn/:socialProvider/:vanityUserId/:vanityUserAlias/:currentModule', component: VanitySynchronizeContactsComponent },
 	{ path: 'share/:alias', component: ShareVideoComponent },
 	{ path: 'embed/:alias', component: ShareVideoComponent },
-	{ path: 'showCampaignVideo/:alias', component: CampaignVideoComponent },
-	{ path: 'showCampaignEmail/:alias', component: LogRegularCampaignComponent },
 	{ path: 'company-page/:alias', component: CompanyPageComponent },
 	{ path: 'partner-page/:alias', component: CompanyPageComponent },
-	{ path: 'loge/:alias', component: LogEmailClickComponent },
-	{ path: 'log/unsubscribe-user', component: LogUnsubscribeComponent },
 	{ path: 'su', component: ServiceUnavailableComponent },
 	{ path: 'access-denied', component: AccessDeniedComponent },
-	{ path: 'rsvp/:alias', component: RsvpComponent },
 	{ path: 'rsvp-response', component: PublicPageResponseComponent },
-	{ path: 'smsShowCampaign/:alias', component: LogRegularCampaignComponentSMS },
-	{ path: 'smsCampaignVideo/:alias', component: CampaignSMSVideoComponent },
-	{ path: 'showEventCampaignSMS/:alias', component: LogEventCampaignComponentSMS },
-	{ path: 'logs/:alias', component: LogSMSClickComponent },
 	{ path: 'f/:alias', component: FormPreviewComponent },
 	{ path: 'mlpf/:alias', component: FormPreviewComponent },
 	{ path: 'mlvjf/:landingPageId/:alias', component: FormPreviewComponent },
@@ -164,7 +141,6 @@ export const routes: Routes = [
 	{ path: 'vjpl/:alias', component: ShowLandingPageComponent },
 	{ path: 'mlpl/:alias', component: ShowLandingPageComponent },
 	{ path: 'mlvjpl/:alias', component: ShowLandingPageComponent },
-	{ path: 'showCampaignLandingPage/:alias', component: ShowLandingPageComponent },
 	{ path: 'scp/:alias', component: ShowLandingPageComponent },
 	{ path: 'clpl/:alias', component: ShowLandingPageComponent },
 	{ path: 'requestdemo', component: RequestDemoComponent },
@@ -172,7 +148,6 @@ export const routes: Routes = [
 	{ path: 'tSignUp/:companyProfileName', component: AccessAccountComponent },
 	{ path: 'tSignUp/:companyProfileName/:alias', component: AccessAccountComponent },
 	{ path: 'pSignUp/:companyProfileName', component: AccessAccountComponent },
-	{ path: 'download/:type', component: DownloadTemplateComponent },
 	{ path: 'samlsecurity/:alias', component: SamlsecurityauthComponent },
 	{ path: 'au/:alias/:moduleToRedirect', component: SamlsecurityauthComponent },
 	{ path: 'vanity-domain-error', component: DomainErrorComponent },
@@ -180,13 +155,7 @@ export const routes: Routes = [
 	{ path: 'login/preview', component: PreviewLoginComponent },
 	{ path: 'pv/t/:id', component: PreviewEmailTemplateComponent, canActivate: [AuthGuard], data: { preload: true } },
 	{ path: 'pv/evt/:id', component: PreviewEmailTemplateComponent, canActivate: [AuthGuard], data: { preload: true } },
-	{ path: 'pv/edevt/:campaignId', component: PreviewEmailTemplateComponent, canActivate: [AuthGuard], data: { preload: true } },
-	{ path: 'pv/ct/:campaignId', component: PreviewEmailTemplateComponent, canActivate: [AuthGuard], data: { preload: true } },
-	{ path: 'pv/ctfe/:campaignId/:fromEmailUserId', component: PreviewEmailTemplateComponent, canActivate: [AuthGuard], data: { preload: true } },
 	{ path: 'pv/ulctp/:id/:fromEmailUserId', component: PreviewEmailTemplateComponent, canActivate: [AuthGuard], data: { preload: true } },
-	{ path: 'pv/sct/:campaignId', component: PreviewEmailTemplateComponent, canActivate: [AuthGuard], data: { preload: true } },
-	{ path: 'pv/sctfe/:campaignId/:fromEmailUserId', component: PreviewEmailTemplateComponent, canActivate: [AuthGuard], data: { preload: true } },
-	{ path: 'pv/sect/:campaignId', component: PreviewEmailTemplateComponent, canActivate: [AuthGuard], data: { preload: true } },
 	{ path: 'pv/scwaret/:id/:fromEmailUserId', component: PreviewEmailTemplateComponent, canActivate: [AuthGuard], data: { preload: true } },
 	{ path: 'pv/cwaret/:id', component: PreviewEmailTemplateComponent, canActivate: [AuthGuard], data: { preload: true } },
 	{ path: 'pv/cwaretfe/:id/:fromEmailUserId', component: PreviewEmailTemplateComponent, canActivate: [AuthGuard], data: { preload: true } },
@@ -221,9 +190,6 @@ export const routes: Routes = [
 
 	{ path: 'mapsUtil', component: MarketplaceMapUtilComponent },
 	{ path: 'marketplaceMap/:alias', component: MarketplaceMapUtilComponent },
-	{ path: 'funding-request/:mdfAlias/analytics', component: CampaignMdfAnalyticsComponent },
-	{ path: 'funding-request/:mdfAlias/preview', component: CampaignMdfTemplatePreviewComponent },
-	{ path: 'search', component: CampaignMdfSearchComponent },
 	{ path: 'pv/otp/:id/:fromEmailUserId', component: PreviewEmailTemplateComponent, canActivate: [AuthGuard], data: { preload: true } },
 
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -18,7 +18,6 @@ import { AppComponent } from './app.component';
 import { SocialLoginComponent } from './social/common/social-login/social-login.component';
 import { SocialCallbackComponent } from './social/common/social-callback/social-callback.component';
 import { ShareVideoComponent } from './videos/share-video/share-video.component';
-import { CampaignVideoComponent } from './videos/campaign-video/campaign-video.component';
 import { RssService } from './social/services/rss.service';
 import { TwitterService } from './social/services/twitter.service';
 import { FacebookService } from './social/services/facebook.service';
@@ -33,7 +32,6 @@ import { ReferenceService } from './core/services/reference.service';
 import { PagerService } from './core/services/pager.service';
 import { EmailTemplateService } from './email-template/services/email-template.service';
 import { EmailSpamCheckService } from './email-template/services/email-spam-check.service';
-import { CampaignService } from './campaigns/services/campaign.service';
 import { AuthenticationService } from './core/services/authentication.service';
 import { SlimLoadingBarService } from 'ng2-slim-loading-bar';
 import { VideoUtilService } from './videos/services/video-util.service';
@@ -45,21 +43,12 @@ import { LoggerService } from './error-pages/services/logger.service';
 import { ConsoleLoggerService } from './error-pages/services/console-logger.service';
 import { XtremandLogger } from './error-pages/xtremand-logger.service';
 
-import { LogEmailClickComponent } from './campaigns/log-email-click/log-email-click.component';
-import { LogUnsubscribeComponent } from './campaigns/log-unsubscribe/log-unsubscribe.component';
-import { LogRegularCampaignComponent } from './campaigns/log-regular-campaign/log-regular-campaign.component';
-import { RsvpComponent } from './campaigns/rsvp/rsvp.component';
 import { EnvServiceProvider } from './env.service.provider';
-import { LogRegularCampaignComponentSMS } from './campaigns/log-regular-campaign-sms/log-regular-campaign-sms.component';
-import { CampaignSMSVideoComponent } from './videos/campaign-sms-video/campaign-sms-video.component';
-import { LogEventCampaignComponentSMS } from './campaigns/log-event-campaign-sms/log-event-campaign-sms.component';
-import { LogSMSClickComponent } from './campaigns/log-sms-click/log-sms-click.component';
 import { ShowLandingPageComponent } from './landing-pages/show-landing-page/show-landing-page.component';
 import { PageNotFoundComponent } from './page-not-found/page-not-found.component';
 
 import { CommonComponentModule } from 'app/common/common.module';
 import { HubSpotService } from './core/services/hubspot.service';
-import { DownloadTemplateComponent } from './campaigns/download-template/download-template.component';
 import { IntegrationService } from './core/services/integration.service';
 import { NgIdleKeepaliveModule } from '@ng-idle/keepalive'; // this includes the core NgIdleModule but includes keepalive providers for easy wireup
 import { VanityURLService } from './vanity-url/services/vanity.url.service';
@@ -79,18 +68,13 @@ import { DatePipe } from '@angular/common';
 import { ConfirmationComponent } from './confirmation/confirmation.component';
 import { ModalModule } from 'ngx-bootstrap/modal';
 import { UrlAuthGuardService } from './core/services/url-auth-guard.service';
-import { CampaignMdfAnalyticsComponent } from './campaigns/campaign-mdf-analytics/campaign-mdf-analytics.component';
-import { CampaignMdfTemplatePreviewComponent } from './campaigns/campaign-mdf-template-preview/campaign-mdf-template-preview.component';
 import { PublicTopNavigationBarComponent } from './util/public-top-navigation-bar/public-top-navigation-bar.component';
-import { CampaignMdfSearchComponent } from './util/campaign-mdf-search/campaign-mdf-search.component';
 
 @NgModule({
     declarations: [AppComponent, SocialLoginComponent, SocialCallbackComponent, ShareVideoComponent,
-        CampaignVideoComponent, LogEmailClickComponent, LogUnsubscribeComponent, LogRegularCampaignComponent, RsvpComponent
-        , LogRegularCampaignComponentSMS, CampaignSMSVideoComponent, RsvpComponent, LogEventCampaignComponentSMS,
-        LogSMSClickComponent, ShowLandingPageComponent, PageNotFoundComponent, DownloadTemplateComponent, VanitySocialLoginComponent, DomainErrorComponent,
+        ShowLandingPageComponent, PageNotFoundComponent, VanitySocialLoginComponent, DomainErrorComponent,
         VanityAddContactsComponent, VanitySynchronizeContactsComponent, VanitySocialContactsCallbackComponent, ConfirmationComponent,
-        CampaignMdfAnalyticsComponent,CampaignMdfTemplatePreviewComponent, PublicTopNavigationBarComponent, CampaignMdfSearchComponent,
+        PublicTopNavigationBarComponent,
     ],
 
     imports: [BrowserAnimationsModule, BrowserModule, FormsModule, HttpModule, HttpClientModule, HttpClientJsonpModule,
@@ -118,7 +102,7 @@ import { CampaignMdfSearchComponent } from './util/campaign-mdf-search/campaign-
 	{provide: ErrorHandler, useClass: ClearChunkFile},
         AuthenticationService, UtilService, UserService, LogService, PagerService, ReferenceService, SocialService, RssService,
         TwitterService, FacebookService, XtremandLogger, VideoUtilService, ParterService,
-        VideoFileService, UploadCloudvideoService, ContactService, EmailTemplateService, EmailSpamCheckService, CampaignService, EnvServiceProvider, HubSpotService, Title, IntegrationService,
+        VideoFileService, UploadCloudvideoService, ContactService, EmailTemplateService, EmailSpamCheckService, EnvServiceProvider, HubSpotService, Title, IntegrationService,
         VanityURLService,LinkedinService,DatePipe,UrlAuthGuardService],
     bootstrap: [AppComponent]
 

--- a/src/app/common/common.module.ts
+++ b/src/app/common/common.module.ts
@@ -12,7 +12,6 @@ import { LocationComponent } from './location/location.component';
 import { PlatformComponent } from './platform/platform.component';
 import { ResponseMessageComponent } from './response-message/response-message.component';
 import { PreviewVideoComponent } from './preview-video/preview-video.component';
-import { ContactsCampaignsMailsComponent } from './contacts-campaigns-mails/contacts-campaigns-mails.component';
 import { PieChartComponent } from '../util/pie-chart/pie-chart.component';
 import { ListLoaderComponent } from './loader/list-loader/list-loader.component';
 import { PlayVideoLoaderComponent } from './loader/play-video-loader/play-video-loader.component';
@@ -45,19 +44,13 @@ import { MergeTagsComponent } from '../util/merge-tags/merge-tags.component';
 import { FlatpickrComponent } from './flatpickr/flatpickr.component';
 import { InternationalPhoneModule } from 'ng4-intl-phone';
 import { SaveGeoLocationAnalyticsComponent } from '../util/save-geo-location-analytics/save-geo-location-analytics.component';
-import { SendCampaignsComponent } from './send-campaigns/send-campaigns.component';
 import { CategoryFolderViewUtilComponent } from '../util/category-folder-view-util/category-folder-view-util.component';
 import { AddFolderModalPopupComponent } from 'app/util/add-folder-modal-popup/add-folder-modal-popup.component';
 import { CreateBeeTemplateComponent } from 'app/util/create-bee-template/create-bee-template.component';
 import { FormsListViewUtilComponent } from 'app/util/forms-list-view-util/forms-list-view-util.component';
-import { CampaignsListViewUtilComponent } from 'app/util/campaigns-list-view-util/campaigns-list-view-util.component';
-import { PreviewCampaignComponent } from "app/campaigns/preview-campaign/preview-campaign.component";
 import { SocialStatusComponent } from '../social/common/social-status/social-status.component';
-import { AddMoreReceiversComponent } from 'app/campaigns/add-more-receivers/add-more-receivers.component';
-import { PublicEventEmailPopupComponent } from 'app/campaigns/public-event-email-popup/public-event-email-popup.component';
 import { TagInputModule } from 'ngx-chips'
 import { LoaderComponent } from '../loader/loader.component';
-import { RedistributeCampaignsListViewUtilComponent } from 'app/util/redistribute-campaigns-list-view-util/redistribute-campaigns-list-view-util.component';
 import { XamplifyDefaultTemplatesComponent } from 'app/util/xamplify-default-templates/xamplify-default-templates.component';
 import { EmailTemplatePreviewUtilComponent } from 'app/util/email-template-preview-util/email-template-preview-util.component';
 import { TranslateModule } from '@ngx-translate/core';
@@ -69,11 +62,9 @@ import { AddFormUtilComponent } from 'app/util/add-form-util/add-form-util.compo
 import { DatePickerComponent } from './date-picker/date-picker.component';
 import { AddLeadComponent } from '../leads/add-lead/add-lead.component';
 import { BeeTemplateUtilComponent } from 'app/util/bee-template-util/bee-template-util.component';
-import { CampaignTemplateDownloadHistoryComponent } from 'app/campaigns/campaign-template-download-history/campaign-template-download-history.component';
 import { ShareLeadsComponent } from './share-leads/share-leads.component';
 import { ImageLoaderComponent } from './image-loader/image-loader.component';
 import { AddTagsUtilComponent } from 'app/util/add-tags-util/add-tags-util.component';
-import { CampaignsLaunchedByPartnersComponent } from 'app/util/campaigns-launched-by-partners/campaigns-launched-by-partners.component';
 import { SpfDescriptionComponent } from 'app/util/spf-description/spf-description.component';
 import { PreviewUserListComponent } from 'app/util/preview-user-list/preview-user-list.component';
 import { AddTracksPlayBookComponent } from 'app/tracks-play-book-util/add-tracks-play-book/add-tracks-play-book.component'
@@ -99,14 +90,11 @@ import { TeamMemberGroupPreviewPopupComponent } from 'app/util/team-member-group
 import { PartnerTeamMemberGroupTeamMembersComponent } from 'app/util/partner-team-member-group-team-members/partner-team-member-group-team-members.component';
 import { TeamMemberFilterOptionComponent } from 'app/util/team-member-filter-option/team-member-filter-option.component';
 import { TeamMemberFilterOptionModalPopupComponent } from 'app/util/team-member-filter-option-modal-popup/team-member-filter-option-modal-popup.component';
-import { ManageCampaignLeadsComponent } from 'app/leads/manage-campaign-leads/manage-campaign-leads.component';
-import { ManageCampaignDealsComponent } from 'app/deals/manage-campaign-deals/manage-campaign-deals.component';
 import { TeamMemberPartnersComponent } from 'app/util/team-member-partners/team-member-partners.component';
 import { MicrosoftAuthenticationPopupComponent } from 'app/contacts/microsoft-authentication-popup/microsoft-authentication-popup.component';
 import { MicrosoftAuthenticationComponent } from 'app/dashboard/microsoft-authentication/microsoft-authentication.component';
 import { FormTeamMemberGroupComponent } from 'app/util/form-team-member-group/form-team-member-group.component';
 import { DisplayDateAndTimeComponent } from './display-date-and-time/display-date-and-time.component';
-import { EditCampaignDetailsModalPopupComponent } from 'app/util/edit-campaign-details-modal-popup/edit-campaign-details-modal-popup.component';
 import { OneClickLaunchPartnerPreviewComponent } from 'app/util/one-click-launch-partner-preview/one-click-launch-partner-preview.component';
 import { CommentsComponent } from 'app/util/comments/comments.component';
 import { FolderTypeViewUtilComponent } from 'app/util/folder-type-view-util/folder-type-view-util.component';
@@ -129,13 +117,11 @@ import { QueryBuilderModule } from "angular2-query-builder";
 import { SelectEmailTemplateComponent } from 'app/util/select-email-template/select-email-template.component';
 import { SendTestEmailComponent } from 'app/util/send-test-email/send-test-email.component';
 import { AddMultipleEmailsInputComponent } from 'app/util/add-multiple-emails-input/add-multiple-emails-input.component';
-import { CampaignListAndGridViewComponent } from 'app/util/campaign-list-and-grid-view/campaign-list-and-grid-view.component';
 import { HomeGuideComponent } from 'app/guides/home-guide/home-guide.component';
 import { EmailTemplatesListAndGridViewComponent } from 'app/util/email-templates/email-templates-list-and-grid-view/email-templates-list-and-grid-view.component';
 import { CustomUiSwitchComponent } from 'app/util/custom-ui-switch/custom-ui-switch.component';
 import { EditTemplateOrPageModalPopupComponent } from 'app/util/edit-template-or-page-modal-popup/edit-template-or-page-modal-popup.component';
 import { ImageUploadCropperComponent } from './image-upload-cropper/image-upload-cropper.component';
-import { ShareCampaignsComponent } from './share-campaigns/share-campaigns.component';
 import { ShareAssetsComponent } from './share-assets/share-assets.component';
 import { SharePlaybooksComponent } from './share-playbooks/share-playbooks.component';
 import { ShareUnpublishedContentComponent } from './share-unpublished-content/share-unpublished-content.component';
@@ -164,11 +150,9 @@ import { UserwiseTrackCountsComponent } from '../util/userwise-track-counts/user
 import { UserwiseTrackDetailsComponent } from '../util/userwise-track-details/userwise-track-details.component';
 import { TrackAssetDetailsComponent } from '../util/track-asset-details/track-asset-details.component';
 import { ShareLeadDetailsComponent } from '../util/share-lead-details/share-lead-details.component';
-import { RedistributedCampaignDetailsComponent } from '../util/redistributed-campaign-details/redistributed-campaign-details.component';
 import { PartnerJourneyLeadDetailsComponent } from '../util/partner-journey-lead-details/partner-journey-lead-details.component';
 import { PartnerJourneyDealDetailsComponent } from '../util/partner-journey-deal-details/partner-journey-deal-details.component';
 import { MdfDetailAnalyticsComponent } from 'app/util/mdf-detail-analytics/mdf-detail-analytics.component';
-import { RedistributedCampaignsAndLeadsBarChartComponent } from '../util/redistributed-campaigns-and-leads-bar-chart/redistributed-campaigns-and-leads-bar-chart.component';
 import { TeamMemberAnalyticsContactDetailsComponent } from 'app/util/team-member-analytics-contact-details/team-member-analytics-contact-details.component';
 import { TeamMemberAnalyticsAllPartnersDetailsComponent } from 'app/util/team-member-analytics-all-partners-details/team-member-analytics-all-partners-details.component';
 import { TeamMemberwiseAssetAnalyticsComponent } from 'app/util/team-member-asset-analytics/team-member-asset-analytics';
@@ -204,7 +188,6 @@ import { DateRangeDisplayComponent } from './date-range-display/date-range-displ
 import { SelectDigitalSignatureComponent } from 'app/util/select-digital-signature/select-digital-signature.component';
 import { SelectfieldComponent } from './selectfield/selectfield.component';
 import { OrderFieldsComponent } from './order-fields/order-fields.component';
-import { CampaignMdfRequestsEmailsSentHistoryComponent } from 'app/util/campaign-mdf-requests-emails-sent-history/campaign-mdf-requests-emails-sent-history.component';
 import { UnlayerBuliderComponent } from 'app/util/unlayer-bulider/unlayer-bulider.component';
 import { AiChatManagerComponent } from 'app/util/ai-chat-manager/ai-chat-manager.component';
 import { MarkdownModule } from 'ngx-markdown';
@@ -220,7 +203,6 @@ import { CustomBlocksModalPopupComponent } from './custom-blocks-modal-popup/cus
 import { CountryPhoneInputComponent } from 'app/util/country-phone-input/country-phone-input.component';
 import { AssetSignatureStatusAnalyticsComponent } from 'app/util/asset-signature-status-analytics/asset-signature-status-analytics.component';
 import { AddCompanyComponent } from '../company/add-company/add-company.component';
-import { CampaignWorkFlowsUtilComponent } from 'app/campaigns/campaign-work-flows-util/campaign-work-flows-util.component';
 import { CreateTemplateComponent } from 'app/util/create-template/create-template.component';
 import { ChooseEmailtemplateComponent } from 'app/util/choose-emailtemplate/choose-emailtemplate.component';
 import { ChatGptIntegrationSettingsComponent } from 'app/dashboard/chat-gpt-integration-settings/chat-gpt-integration-settings.component';
@@ -230,12 +212,10 @@ import { AddLandingPageComponent } from 'app/landing-pages/add-landing-page/add-
 import { DomainColorConfigurationComponent } from 'app/util/domain-color-configuration/domain-color-configuration.component';
 
 import { ExecutiveSummaryReportComponent } from 'app/executive-summary-report/executive-summary-report.component';
-import { SelectPartnersAndShareLeadsComponent } from 'app/campaigns/select-partners-and-share-leads/select-partners-and-share-leads.component';
 import { InviteTeamMemberModalPopupComponent } from 'app/util/invite-team-member-modal-popup/invite-team-member-modal-popup.component';
 import { DamAnalyticsDetailsComponent } from 'app/dam/dam-analytics-details/dam-analytics-details.component';
 import { PptDesignPickerComponent } from 'app/util/ppt-design-picker/ppt-design-picker.component';
 import { SelectAssetTypeFilterPipe } from 'app/dam/select-asset-type-filter.pipe';
-import { SelectManageCampaignComponent } from 'app/campaigns/select-manage-campaign/select-manage-campaign.component';
 
 @NgModule({
 	imports: [InternationalPhoneModule, RecaptchaModule.forRoot(), CommonModule, FormsModule, LoadingModule, MultiSelectAllModule, CheckBoxModule, ButtonModule, BootstrapSwitchModule, TagInputModule, TranslateModule,
@@ -243,88 +223,57 @@ import { SelectManageCampaignComponent } from 'app/campaigns/select-manage-campa
 		 ScrollToModule.forRoot(),AngularMultiSelectModule,MarkdownModule.forRoot()],
 	declarations: [DonutChartComponent, PaginationComponent, WorldmapComponent, PieChartComponent,AddCompanyComponent,
 		BarChartComponent, EmbedModalComponent, EmbedModalComponent, UserInfoComponent, LocationComponent,
-		PlatformComponent, ResponseMessageComponent, PreviewVideoComponent, ContactsCampaignsMailsComponent, ListLoaderComponent,
 		PlayVideoLoaderComponent, GridLoaderComponent, ExportCsvComponent, AnalyticsLoaderComponent, VideoThumbnailComponent,
 		TimestampComponent, ScrollTopComponent, SaveAsComponent, TimestampNewComponent, VideoPlayComponent, EventSendReminderComponent,
 		ImageCropperComponent, EmailSpamCheckComponent, AutoResponseLoaderComponent, PreviewPopupComponent, PreviewLandingPageComponent, FormPreviewComponent,
 		LandingPageLoaderComponent, DashboardLoaderComponent, ModalPopupLoaderComponent, PublicPageResponseComponent, MergeTagsComponent, FlatpickrComponent, SaveGeoLocationAnalyticsComponent,
-		SendCampaignsComponent, CategoryFolderViewUtilComponent, AddFolderModalPopupComponent, CreateBeeTemplateComponent, FormsListViewUtilComponent,
-		CampaignsListViewUtilComponent, PreviewCampaignComponent, SocialStatusComponent,
-		AddMoreReceiversComponent, PublicEventEmailPopupComponent, LoaderComponent, RedistributeCampaignsListViewUtilComponent, XamplifyDefaultTemplatesComponent, 
-		EmailTemplatePreviewUtilComponent, AddFormUtilComponent, AddTracksPlayBookComponent, AddTagsUtilComponent, DatePickerComponent, AddLeadComponent, BeeTemplateUtilComponent, CampaignTemplateDownloadHistoryComponent,
-		ShareLeadsComponent, ImageLoaderComponent, CampaignsLaunchedByPartnersComponent, SpfDescriptionComponent, ManageTracksPlayBookComponent, PreviewTracksPlayBookComponent,
 		TracksPlayBookAnalyticsComponent, TracksPlayBookPartnerAnalyticsComponent, PreviewUserListComponent, 
 		TracksPlayBookPartnerCompanyAndListsComponent, AddDefaultTemplateDetailsComponent, UserlistUsersComponent, PartnerCompanyModalPopupComponent,
 		FormPreviewWithSubmittedAnswersComponent,TeamMembersUtilComponent,ConfirmSweetAlertUtilComponent,ChartPieComponent, ChartVariablePieComponent,
 		SelectDropdownComponent,PreviewAssetPopupComponent,AssetGridViewActionsComponent,DownloadAssetPopupComponent,DeleteAssetsComponent,
 		TeamMemberGroupPreviewPopupComponent,PartnerTeamMemberGroupTeamMembersComponent,TeamMemberFilterOptionComponent,TeamMemberFilterOptionModalPopupComponent,
-		ManageCampaignLeadsComponent,ManageCampaignDealsComponent,TeamMemberPartnersComponent, FormTeamMemberGroupComponent, DisplayDateAndTimeComponent,
-		EditCampaignDetailsModalPopupComponent,OneClickLaunchPartnerPreviewComponent,MicrosoftAuthenticationPopupComponent,MicrosoftAuthenticationComponent,
 		CommentsComponent,FolderTypeViewUtilComponent,DamListAndGridViewComponent,CountStatisticsComponent,ImgCropprV2Component,
 		LoginAsPartnerComponent,PipedriveAuthenticationPopupComponent,ConnectwiseAuthenticationPopupComponent,CopyGroupUsersModalPopupComponent,
 		PartnerCompanyAndGroupsComponent,XamplifyVideoPlayerComponent,SendTestEmailComponent,AddMultipleEmailsInputComponent,
-		CampaignListAndGridViewComponent,UserGuideHelpButtonComponent,GuideLeftMenuComponent,SearchGuidesComponent,GuideHelpIconComponent,
 		HomeGuideComponent,EmailTemplatesListAndGridViewComponent,DonutPieChartComponent,AllPartnersListComponent,SelectEmailTemplateComponent,CustomUiSwitchComponent,
-		EditTemplateOrPageModalPopupComponent, ShareCampaignsComponent, ShareAssetsComponent, SharePlaybooksComponent,
 		ShareUnpublishedContentComponent, ShareTracksOrPlaybooksComponent,ImageUploadCropperComponent,SearchableDropdownComponent,
 		ConfirmUnpublishTracksOrPlaybooksModelPopupComponent,CustomUiFilterComponent,TrimPipe,CopyModalPopupComponent,
 		LandingPagesListAndGridViewComponent,BrowseContentComponent,DealChatPopupComponent,
 		ChatComponent,OpportunitiesChatModalPopupComponent,UploadImageUtilComponent,PreviewEmailTemplateComponent,PreviewPageComponent,PreviewAssetPdfComponent,PartnerJourneyCountTilesComponent,BoxLoaderComponent,InteractedNotInteractedTrackDetailsComponent,
 		TypewiseTrackContentDetailsComponent,UserwiseTrackCountsComponent,UserwiseTrackDetailsComponent,TrackAssetDetailsComponent,
-		ShareLeadDetailsComponent,RedistributedCampaignDetailsComponent,PartnerJourneyLeadDetailsComponent,PartnerJourneyDealDetailsComponent,
-		MdfDetailAnalyticsComponent,RedistributedCampaignsAndLeadsBarChartComponent,TeamMemberAnalyticsContactDetailsComponent,TeamMemberAnalyticsAllPartnersDetailsComponent,
 		TeamMemberwiseAssetAnalyticsComponent,TeamMemberwiseAssetsDetailedReportComponent,TeamMemberAnalyticsCompanyDetailsComponent,FilePreviewComponent,DomainWhitelistingComponent,BackgroundImageUploadComponent,SamlSsoLoginComponent,
 		OauthSsoConfigurationComponent, ShareDashboardButtonsComponent,CrmSettingsComponent,
 		DropdownLoaderComponent,DisplayErrorMessageComponent, ChatGptModalComponent,MultiSelectDropdownComponent, CopyTextComponent, AccessDeniedUtilComponent, VendorCompanyModelPopupComponent, UniversalSearchBarComponent,
 		ContentStatusHistoryModalPopupComponent, AssetApprovalConfigurationSettingsComponent, ContentModuleStatusAnalyticsComponent, 
 		TeamMemberWiseAssetDetailsComponent,DigitalSignatureComponent,SignatureComponent,UploadImageComponent,DateRangeDisplayComponent,
-		MultiselectApprovalCommentsModalPopupComponent,SelectDigitalSignatureComponent,CampaignMdfRequestsEmailsSentHistoryComponent, SelectfieldComponent, OrderFieldsComponent,UnlayerBuliderComponent,AiChatManagerComponent,AddEmailModalPopupComponent,
-		UpdateStatusComponent,ConnectAccountsComponent,FeedUpdateComponent,FeedComponent,RssLoaderComponent,AircallDialerComponent, CustomBlocksModalPopupComponent, PreviewContentComponent, CountryPhoneInputComponent, AssetSignatureStatusAnalyticsComponent, CampaignWorkFlowsUtilComponent,
-		CreateTemplateComponent,ChooseEmailtemplateComponent, ChatGptIntegrationSettingsComponent,AddDamComponent,PartnerCompanyDomainModalPopupComponent,AddLandingPageComponent, ExecutiveSummaryReportComponent, DomainColorConfigurationComponent, SelectPartnersAndShareLeadsComponent, InviteTeamMemberModalPopupComponent,DamAnalyticsDetailsComponent,PptDesignPickerComponent,SelectAssetTypeFilterPipe, SelectManageCampaignComponent
 	],
 
 
-	exports: [InternationalPhoneModule,AddCompanyComponent, RecaptchaModule, DonutChartComponent, PaginationComponent, WorldmapComponent, ContactsCampaignsMailsComponent, TagInputModule,
 		BarChartComponent, EmbedModalComponent, UserInfoComponent, LocationComponent, PlatformComponent, ImageCropperComponent,
 		ResponseMessageComponent, PreviewVideoComponent, PieChartComponent, ListLoaderComponent, GridLoaderComponent, PlayVideoLoaderComponent,
 		ExportCsvComponent, LoadingModule, AnalyticsLoaderComponent, VideoThumbnailComponent, TimestampComponent,
 		ScrollTopComponent, SaveAsComponent, TimestampNewComponent, VideoPlayComponent, EventSendReminderComponent, EmailSpamCheckComponent, AutoResponseLoaderComponent,
 		PreviewPopupComponent, PreviewLandingPageComponent, FormPreviewComponent, LandingPageLoaderComponent, DashboardLoaderComponent, ModalPopupLoaderComponent,
-		MergeTagsComponent, FlatpickrComponent, SaveGeoLocationAnalyticsComponent, SendCampaignsComponent, CategoryFolderViewUtilComponent,
-		AddFolderModalPopupComponent, CreateBeeTemplateComponent, FormsListViewUtilComponent, CampaignsListViewUtilComponent,
-		PreviewCampaignComponent, SocialStatusComponent, AddMoreReceiversComponent, PublicEventEmailPopupComponent, LoaderComponent,
-		RedistributeCampaignsListViewUtilComponent, XamplifyDefaultTemplatesComponent, EmailTemplatePreviewUtilComponent, AddFormUtilComponent, AddTagsUtilComponent, 
-		AddTracksPlayBookComponent, DatePickerComponent, AddLeadComponent, BeeTemplateUtilComponent, CampaignTemplateDownloadHistoryComponent,
-		ShareLeadsComponent, ImageLoaderComponent, CampaignsLaunchedByPartnersComponent, SpfDescriptionComponent, ManageTracksPlayBookComponent, PreviewTracksPlayBookComponent, 
 		TracksPlayBookAnalyticsComponent, TracksPlayBookPartnerAnalyticsComponent, PreviewUserListComponent, 
 		TracksPlayBookPartnerCompanyAndListsComponent, AddDefaultTemplateDetailsComponent, UserlistUsersComponent, PartnerCompanyModalPopupComponent,
 		FormPreviewWithSubmittedAnswersComponent,TeamMembersUtilComponent,ConfirmSweetAlertUtilComponent,ChartPieComponent, ChartVariablePieComponent,
 		SelectDropdownComponent,PreviewAssetPopupComponent,AssetGridViewActionsComponent,DownloadAssetPopupComponent,DeleteAssetsComponent,
 		TeamMemberGroupPreviewPopupComponent,PartnerTeamMemberGroupTeamMembersComponent,TeamMemberFilterOptionComponent,TeamMemberFilterOptionModalPopupComponent,
-		ManageCampaignLeadsComponent,ManageCampaignDealsComponent,TeamMemberPartnersComponent, FormTeamMemberGroupComponent,DisplayDateAndTimeComponent,
-		EditCampaignDetailsModalPopupComponent,OneClickLaunchPartnerPreviewComponent,MicrosoftAuthenticationPopupComponent,MicrosoftAuthenticationComponent,
 		CommentsComponent,FolderTypeViewUtilComponent,DamListAndGridViewComponent,CountStatisticsComponent,
 		ImgCropprV2Component,LoginAsPartnerComponent,PipedriveAuthenticationPopupComponent,ConnectwiseAuthenticationPopupComponent,CopyGroupUsersModalPopupComponent,
 		PartnerCompanyAndGroupsComponent,XamplifyVideoPlayerComponent,SendTestEmailComponent,AddMultipleEmailsInputComponent,
-		CampaignListAndGridViewComponent,UserGuideHelpButtonComponent,EmailTemplatesListAndGridViewComponent,
 		DonutPieChartComponent,AllPartnersListComponent,QueryBuilderModule,SelectEmailTemplateComponent,CustomUiSwitchComponent,EditTemplateOrPageModalPopupComponent,
-		ShareCampaignsComponent, ShareAssetsComponent, SharePlaybooksComponent,
 		ShareUnpublishedContentComponent,ShareTracksOrPlaybooksComponent,ImageUploadCropperComponent,SearchableDropdownComponent,
 		ScrollToModule,ConfirmUnpublishTracksOrPlaybooksModelPopupComponent,CustomUiFilterComponent,TrimPipe,CopyModalPopupComponent,
 		LandingPagesListAndGridViewComponent,BrowseContentComponent,DealChatPopupComponent,ChatComponent,
 		OpportunitiesChatModalPopupComponent,UploadImageUtilComponent,PreviewEmailTemplateComponent,PreviewPageComponent,PreviewAssetPdfComponent,PartnerJourneyCountTilesComponent,BoxLoaderComponent,
 		InteractedNotInteractedTrackDetailsComponent,TypewiseTrackContentDetailsComponent,UserwiseTrackCountsComponent,UserwiseTrackDetailsComponent,TrackAssetDetailsComponent,
-		ShareLeadDetailsComponent,RedistributedCampaignDetailsComponent,PartnerJourneyLeadDetailsComponent,PartnerJourneyDealDetailsComponent,MdfDetailAnalyticsComponent,
-		RedistributedCampaignsAndLeadsBarChartComponent,TeamMemberAnalyticsContactDetailsComponent,TeamMemberAnalyticsAllPartnersDetailsComponent,TeamMemberwiseAssetAnalyticsComponent,
 		TeamMemberwiseAssetsDetailedReportComponent,TeamMemberAnalyticsCompanyDetailsComponent,FilePreviewComponent,DomainWhitelistingComponent,BackgroundImageUploadComponent,SamlSsoLoginComponent,
 		OauthSsoConfigurationComponent,CrmSettingsComponent,ShareDashboardButtonsComponent,
 		DropdownLoaderComponent,DisplayErrorMessageComponent,ChatGptModalComponent,MultiSelectDropdownComponent,CopyTextComponent,AccessDeniedUtilComponent, VendorCompanyModelPopupComponent,
 		UniversalSearchBarComponent, ContentStatusHistoryModalPopupComponent, AssetApprovalConfigurationSettingsComponent, 
 		ContentModuleStatusAnalyticsComponent, TeamMemberWiseAssetDetailsComponent,DigitalSignatureComponent,SignatureComponent,
-		UploadImageComponent,DateRangeDisplayComponent,MultiselectApprovalCommentsModalPopupComponent,SelectDigitalSignatureComponent,CampaignMdfRequestsEmailsSentHistoryComponent,SelectfieldComponent,
 		OrderFieldsComponent,UnlayerBuliderComponent,AiChatManagerComponent,AddEmailModalPopupComponent,UpdateStatusComponent,ConnectAccountsComponent,FeedUpdateComponent,FeedComponent,RssLoaderComponent,
-		AircallDialerComponent, CustomBlocksModalPopupComponent, PreviewContentComponent, CountryPhoneInputComponent, AssetSignatureStatusAnalyticsComponent, CreateTemplateComponent, ChooseEmailtemplateComponent , CampaignWorkFlowsUtilComponent, ChatGptIntegrationSettingsComponent,
-		AddDamComponent,PartnerCompanyDomainModalPopupComponent,AddLandingPageComponent, ExecutiveSummaryReportComponent, DomainColorConfigurationComponent, SelectPartnersAndShareLeadsComponent, InviteTeamMemberModalPopupComponent,DamAnalyticsDetailsComponent, PptDesignPickerComponent,SelectAssetTypeFilterPipe, SelectManageCampaignComponent
 	]
 
 

--- a/src/app/core/services/authentication.service.ts
+++ b/src/app/core/services/authentication.service.ts
@@ -33,7 +33,6 @@ import { TracksPlayBookType } from 'app/tracks-play-book-util/models/tracks-play
 import { Properties } from 'app/common/models/properties';
 import { XAMPLIFY_CONSTANTS } from 'app/constants/xamplify-default.constants';
 import { RequestDemo } from 'app/authentication/request-demo/request-demo';
-import { DuplicateMdfRequest } from 'app/campaigns/models/duplicate-mdf-request';
 import { PartnerPrimaryAdminUpdateDto } from 'app/partners/models/partner-primary-admin-update-dto';
 
 
@@ -1579,11 +1578,6 @@ vanityWelcomePageRequired(userId) {
     requestDemo.mdfRequest = true;
     let url = this.REST_URL + 'campaign-mdf/request-account';
     return this.callPostMethod(url,requestDemo);
-  }
-
-  validateDuplicateMdfRequest(duplicateMdfRequestDto:DuplicateMdfRequest) {
-    const url = this.REST_URL + 'campaign/validateDuplicateCampaignMdfRequest?emailAddress='+duplicateMdfRequestDto.emailAddress+'&campaignId='+duplicateMdfRequestDto.campaignId+'&access_token='+this.access_token;
-    return this.callGetMethod(url);
   }
 
   /***XNFR-878****/

--- a/src/app/core/services/reference.service.ts
+++ b/src/app/core/services/reference.service.ts
@@ -14,8 +14,6 @@ import { SenderMergeTag } from "../../core/models/sender-merge-tag";
 import { Timezone } from "../../core/models/timezone";
 import { Ng2DeviceService } from "ng2-device-detector";
 import { EmailTemplate } from "../../email-template/models/email-template";
-import { Campaign } from "../../campaigns/models/campaign";
-import { CampaignAccess } from "app/campaigns/models/campaign-access";
 import { Properties } from "../../common/models/properties";
 import { CustomResponse } from "../../common/models/custom-response";
 import { User } from "../../core/models/user";
@@ -114,7 +112,7 @@ export class ReferenceService {
   selectedVideoLogodesc: string;
   contentManagementLoader: boolean;
   namesArray: any;
-  campaignAccess: CampaignAccess;
+  campaignAccess: any;
   manageRouter = false;
   detailViewIsLoading: boolean;
   videoCampaign = false;
@@ -1934,7 +1932,7 @@ export class ReferenceService {
     updatedBody: string,
     partnerLogo: string,
     partnerCompanyUrl: string,
-    campaign: Campaign
+    campaign: any
   ) {
     if (campaign.partnerCompanyLogo != undefined) {
       partnerLogo = campaign.partnerCompanyLogo;
@@ -2117,7 +2115,7 @@ export class ReferenceService {
   }
 
   showEmailTemplatePreview(
-    campaign: Campaign,
+    campaign: any,
     campaignType: string,
     selectedVideoGifPath: string,
     emailTemplateBody: string


### PR DESCRIPTION
## Summary
- remove campaign routes, services, and components
- drop duplicate MDF validation and campaign access types

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b93150e17c832bb86b014f73d1176b