### PR TITLE
chore: stub campaign module and fix common module

### DIFF
--- a/src/app/campaigns/add-more-receivers/add-more-receivers.component.ts
+++ b/src/app/campaigns/add-more-receivers/add-more-receivers.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-add-more-receivers',
+  template: ''
+})
+export class AddMoreReceiversComponent {}
+

--- a/src/app/campaigns/analytics/detailed-campaign-analytics/detailed-campaign-analytics.component.ts
+++ b/src/app/campaigns/analytics/detailed-campaign-analytics/detailed-campaign-analytics.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-detailed-campaign-analytics',
+  template: ''
+})
+export class DetailedCampaignAnalyticsComponent {}
+

--- a/src/app/campaigns/campaign-template-download-history/campaign-template-download-history.component.ts
+++ b/src/app/campaigns/campaign-template-download-history/campaign-template-download-history.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-campaign-template-download-history',
+  template: ''
+})
+export class CampaignTemplateDownloadHistoryComponent {}
+

--- a/src/app/campaigns/campaign-work-flows-util/campaign-work-flows-util.component.ts
+++ b/src/app/campaigns/campaign-work-flows-util/campaign-work-flows-util.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-campaign-work-flows-util',
+  template: ''
+})
+export class CampaignWorkFlowsUtilComponent {}
+

--- a/src/app/campaigns/campaigns.module.ts
+++ b/src/app/campaigns/campaigns.module.ts
@@ -1,0 +1,6 @@
+import { NgModule } from '@angular/core';
+
+// Stub module to satisfy module imports after the campaign feature removal.
+@NgModule({})
+export class CampaignsModule {}
+

--- a/src/app/campaigns/models/campaign-details-dto.ts
+++ b/src/app/campaigns/models/campaign-details-dto.ts
@@ -1,0 +1,4 @@
+export class CampaignDetailsDto {
+  // Minimal DTO used for editing campaign details.
+}
+

--- a/src/app/campaigns/models/campaign-reply.ts
+++ b/src/app/campaigns/models/campaign-reply.ts
@@ -1,0 +1,4 @@
+export class Reply {
+  // Stub for campaign reply information.
+}
+

--- a/src/app/campaigns/models/campaign-report.ts
+++ b/src/app/campaigns/models/campaign-report.ts
@@ -1,0 +1,4 @@
+export class CampaignReport {
+  // Placeholder for legacy campaign reporting structure.
+}
+

--- a/src/app/campaigns/models/campaign.ts
+++ b/src/app/campaigns/models/campaign.ts
@@ -1,0 +1,5 @@
+export class Campaign {
+  // Stub model used to retain compatibility after campaign module removal.
+  // Add properties as needed.
+}
+

--- a/src/app/campaigns/models/duplicate-mdf-request.ts
+++ b/src/app/campaigns/models/duplicate-mdf-request.ts
@@ -1,0 +1,4 @@
+export class DuplicateMdfRequest {
+  // Placeholder for MDF request duplication check.
+}
+

--- a/src/app/campaigns/models/email-log.ts
+++ b/src/app/campaigns/models/email-log.ts
@@ -1,0 +1,4 @@
+export class EmailLog {
+  // Minimal representation of an email log entry.
+}
+

--- a/src/app/campaigns/models/event-campaign.ts
+++ b/src/app/campaigns/models/event-campaign.ts
@@ -1,0 +1,4 @@
+export class EventCampaign {
+  // Placeholder for event campaign details.
+}
+

--- a/src/app/campaigns/public-event-email-popup/public-event-email-popup.component.ts
+++ b/src/app/campaigns/public-event-email-popup/public-event-email-popup.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-public-event-email-popup',
+  template: ''
+})
+export class PublicEventEmailPopupComponent {}
+

--- a/src/app/campaigns/services/campaign.service.ts
+++ b/src/app/campaigns/services/campaign.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class CampaignService {
+  // This is a placeholder service to satisfy compilation after the
+  // removal of the real campaign implementation.
+  // Any property or method access on this service will compile to `any`.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+}
+

--- a/src/app/common/common.module.ts
+++ b/src/app/common/common.module.ts
@@ -245,11 +245,11 @@ import { SelectAssetTypeFilterPipe } from 'app/dam/select-asset-type-filter.pipe
 		OauthSsoConfigurationComponent, ShareDashboardButtonsComponent,CrmSettingsComponent,
 		DropdownLoaderComponent,DisplayErrorMessageComponent, ChatGptModalComponent,MultiSelectDropdownComponent, CopyTextComponent, AccessDeniedUtilComponent, VendorCompanyModelPopupComponent, UniversalSearchBarComponent,
 		ContentStatusHistoryModalPopupComponent, AssetApprovalConfigurationSettingsComponent, ContentModuleStatusAnalyticsComponent, 
-		TeamMemberWiseAssetDetailsComponent,DigitalSignatureComponent,SignatureComponent,UploadImageComponent,DateRangeDisplayComponent,
-	],
+          TeamMemberWiseAssetDetailsComponent,DigitalSignatureComponent,SignatureComponent,UploadImageComponent,DateRangeDisplayComponent,
+          ],
 
-
-		BarChartComponent, EmbedModalComponent, UserInfoComponent, LocationComponent, PlatformComponent, ImageCropperComponent,
+        exports: [
+                BarChartComponent, EmbedModalComponent, UserInfoComponent, LocationComponent, PlatformComponent, ImageCropperComponent,
 		ResponseMessageComponent, PreviewVideoComponent, PieChartComponent, ListLoaderComponent, GridLoaderComponent, PlayVideoLoaderComponent,
 		ExportCsvComponent, LoadingModule, AnalyticsLoaderComponent, VideoThumbnailComponent, TimestampComponent,
 		ScrollTopComponent, SaveAsComponent, TimestampNewComponent, VideoPlayComponent, EventSendReminderComponent, EmailSpamCheckComponent, AutoResponseLoaderComponent,
@@ -273,11 +273,7 @@ import { SelectAssetTypeFilterPipe } from 'app/dam/select-asset-type-filter.pipe
 		DropdownLoaderComponent,DisplayErrorMessageComponent,ChatGptModalComponent,MultiSelectDropdownComponent,CopyTextComponent,AccessDeniedUtilComponent, VendorCompanyModelPopupComponent,
 		UniversalSearchBarComponent, ContentStatusHistoryModalPopupComponent, AssetApprovalConfigurationSettingsComponent, 
 		ContentModuleStatusAnalyticsComponent, TeamMemberWiseAssetDetailsComponent,DigitalSignatureComponent,SignatureComponent,
-		OrderFieldsComponent,UnlayerBuliderComponent,AiChatManagerComponent,AddEmailModalPopupComponent,UpdateStatusComponent,ConnectAccountsComponent,FeedUpdateComponent,FeedComponent,RssLoaderComponent,
-	]
-
-
-
-
+                OrderFieldsComponent,UnlayerBuliderComponent,AiChatManagerComponent,AddEmailModalPopupComponent,UpdateStatusComponent,ConnectAccountsComponent,FeedUpdateComponent,FeedComponent,RssLoaderComponent,
+        ]
 })
 export class CommonComponentModule { }

--- a/src/app/core/services/authentication.service.ts
+++ b/src/app/core/services/authentication.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { Http, Headers, Response, RequestOptions } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs';
+import 'rxjs/add/observable/of';
 import { EnvService } from 'app/env.service';
 import { Router } from '@angular/router';
 import 'rxjs/add/operator/map';
@@ -1671,6 +1672,11 @@ vanityWelcomePageRequired(userId) {
     }
     if (buf) out.push(buf);
     return out;
+  }
+
+  validateDuplicateMdfRequest(_req: any): Observable<any> {
+    // Placeholder API call. The real implementation was removed with campaign features.
+    return Observable.of({});
   }
 
   sendEmailToUser (sendTestEmailDto: SendTestEmailDto, formData: FormData) {

--- a/src/app/landing-pages/landing-page-analytics/landing-page-analytics.component.ts
+++ b/src/app/landing-pages/landing-page-analytics/landing-page-analytics.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-landing-page-analytics',
+  template: ''
+})
+export class LandingPageAnalyticsComponent {}
+


### PR DESCRIPTION
## Summary
- add placeholder campaign service, models, and components for removed campaign feature
- add landing page analytics stub
- fix CommonComponentModule exports and add AuthenticationService duplicate request helper

## Testing
- `npm test` *(fails: sh: 1: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b94ec6e634832bac6cbd4d5dcd8bab