### PR TITLE
Allow PRM signup email editing

### DIFF
--- a/src/app/authentication/signup/signup.component.html
+++ b/src/app/authentication/signup/signup.component.html
@@ -59,8 +59,8 @@
 				</div>
 				<div class="form-group">
 					<label class="control-label visible-ie8 visible-ie9">Email</label>
-					<input class="form-control placeholder-no-fix emailTF" type="email" placeholder="Email" required
-						formControlName="emailId" (keyup)="validEmail($event)" disabled />
+                                       <input class="form-control placeholder-no-fix emailTF" type="email" placeholder="Email" required
+                                               formControlName="emailId" (keyup)="validEmail($event)" [disabled]="!prmSignup" />
 					<div *ngIf="formErrors.emailId && !invalidVendor" class="alert alert-danger">
 						{{ formErrors.emailId }}</div>
 					<div *ngIf="formErrors.emailId && invalidVendor" class="alert alert-danger">{{formErrors.emailId }}

--- a/src/app/authentication/signup/signup.component.spec.ts
+++ b/src/app/authentication/signup/signup.component.spec.ts
@@ -1,6 +1,17 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { ReactiveFormsModule } from '@angular/forms';
+import { Router, ActivatedRoute } from '@angular/router';
 import { SignupComponent } from './signup.component';
+import { CountryNames } from '../../common/models/country-names';
+import { RegularExpressions } from '../../common/models/regular-expressions';
+import { Properties } from '../../common/models/properties';
+import { User } from '../../core/models/user';
+import { UserService } from '../../core/services/user.service';
+import { ReferenceService } from '../../core/services/reference.service';
+import { XtremandLogger } from '../../error-pages/xtremand-logger.service';
+import { AuthenticationService } from '../../core/services/authentication.service';
+import { VanityURLService } from '../../vanity-url/services/vanity.url.service';
+import { DomSanitizer } from '@angular/platform-browser';
 
 describe('SignupComponent', () => {
   let component: SignupComponent;
@@ -8,7 +19,22 @@ describe('SignupComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ SignupComponent ]
+      declarations: [SignupComponent],
+      imports: [ReactiveFormsModule],
+      providers: [
+        CountryNames,
+        RegularExpressions,
+        Properties,
+        User,
+        { provide: Router, useValue: { url: '/prm-signup' } },
+        { provide: ActivatedRoute, useValue: { snapshot: { params: {} } } },
+        { provide: UserService, useValue: {} },
+        { provide: ReferenceService, useValue: { showInputPassword: false, showInputConfirmPassword: false, showPassword: () => {} } },
+        { provide: XtremandLogger, useValue: { error: () => {}, log: () => {}, errorPage: () => {} } },
+        { provide: AuthenticationService, useValue: { companyProfileName: '', getUserId: () => {}, navigateToDashboardIfUserExists: () => {} } },
+        { provide: VanityURLService, useValue: { isVanityURLEnabled: () => false } },
+        { provide: DomSanitizer, useValue: { bypassSecurityTrustHtml: (v: any) => v } }
+      ]
     })
     .compileComponents();
   }));
@@ -22,4 +48,9 @@ describe('SignupComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should enable email field for PRM sign up', () => {
+    expect(component.signUpForm.get('emailId')?.enabled).toBeTrue();
+  });
 });
+

--- a/src/app/authentication/signup/signup.component.ts
+++ b/src/app/authentication/signup/signup.component.ts
@@ -207,6 +207,9 @@ export class SignupComponent implements OnInit,AfterViewInit, OnDestroy {
         this.signUpForm.valueChanges
             .subscribe(data => this.onValueChanged(data));
         this.onValueChanged(); // (re)set validation messages now
+        if (!this.prmSignup) {
+            this.signUpForm.get('emailId')?.disable();
+        }
     }
 
     onValueChanged(data?: any) {


### PR DESCRIPTION
## Summary
- make email field editable during PRM signup by binding the disabled state
- disable email field programmatically for non-PRM flows
- add unit test ensuring the email field is enabled when PRM signup is active

## Testing
- `npm test` *(fails: ng: not found)*
- `npm install` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_b_68c3da37e59c832898caea5fe9d81946