### PR TITLE
refactor signup email control disable

### DIFF
--- a/src/app/authentication/signup/signup.component.spec.ts
+++ b/src/app/authentication/signup/signup.component.spec.ts
@@ -50,7 +50,7 @@ describe('SignupComponent', () => {
   });
 
   it('should enable email field for PRM sign up', () => {
-    expect(component.signUpForm.get('emailId')?.enabled).toBeTrue();
+    expect(component.signUpForm.get('emailId')!.enabled).toBeTrue();
   });
 });
 

--- a/src/app/authentication/signup/signup.component.ts
+++ b/src/app/authentication/signup/signup.component.ts
@@ -236,7 +236,10 @@ export class SignupComponent implements OnInit,AfterViewInit, OnDestroy {
             .subscribe(data => this.onValueChanged(data));
         this.onValueChanged(); // (re)set validation messages now
         if (!this.prmSignup) {
-            this.signUpForm.get('emailId')?.disable();
+            const emailCtrl = this.signUpForm.get('emailId');
+            if (emailCtrl) {
+                emailCtrl.disable();
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- safely disable signup email field without optional chaining
- use non-null assertion in signup component spec

## Testing
- `npm run build` *(fails: ng not found)*
- `npm install` *(fails: 403 fetching packages)*

------
https://chatgpt.com/codex/tasks/task_b_68c3fbf2b55c8328a5a1f2ed526a38f1