### PR TITLE
Rename project references to xamplify-prm-ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# XtremandWebCli
+# xamplify-prm-ui
 
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 1.4.2.
 
@@ -12,7 +12,7 @@ To get started locally, follow these instructions:
 `npm install -g @angular/cli@1.4.2`
 check if the cli installed properly or not with `ng --version` command
 
-3.Clone the `xtremand-web-cli` project to your local computer using `git`
+3.Clone the `xamplify-prm-ui` project to your local computer using `git`
 
 4.Run `npm install` to download the node modules of your project. Those files will help you to run the project locally.
 

--- a/e2e/app.e2e-spec.ts
+++ b/e2e/app.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { BasePage } from './app.po';
 import { browser } from 'protractor';
 
-describe('xtremand-web-cli App', () => {
+describe('xamplify-prm-ui App', () => {
   let page: BasePage;
 
   beforeEach(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "xtremand-web-cli",
+  "name": "xamplify-prm-ui",
   "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "xtremand-web-cli",
+  "name": "xamplify-prm-ui",
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
## Summary
- Update package metadata and docs to use new project name `xamplify-prm-ui`
- Adjust e2e tests to reference `xamplify-prm-ui`

## Testing
- `npm test` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c52830590c8328a136abaf82f420e5