### PR TITLE
refactor: rename campaign access to module access

### DIFF
--- a/src/app/auth-guard.service.ts
+++ b/src/app/auth-guard.service.ts
@@ -51,7 +51,7 @@ export class AuthGuardService implements CanActivate {
     this.authenticationService.user.emailId = user.userName;
     this.authenticationService.user.roles = user.roles;
     this.authenticationService.user.hasCompany = user.hasCompany;
-    this.authenticationService.user.campaignAccessDto = user.campaignAcessDto;
+    this.authenticationService.user.moduleAccessDto = user.moduleAccessDto || user.campaignAcessDto;
     this.authenticationService.user.secondAdmin = user.secondAdmin;
   }
 

--- a/src/app/auth.guard.ts
+++ b/src/app/auth.guard.ts
@@ -64,7 +64,7 @@ export class AuthGuard implements CanActivate, CanActivateChild {
                 this.authenticationService.user.emailId = userName;
                 this.authenticationService.user.roles = JSON.parse(currentUser)['roles'];
                 this.authenticationService.user.hasCompany = JSON.parse(currentUser)['hasCompany'];
-                this.authenticationService.user.campaignAccessDto = JSON.parse(currentUser)['campaignAccessDto'];
+                this.authenticationService.user.moduleAccessDto = JSON.parse(currentUser)['moduleAccessDto'] || JSON.parse(currentUser)['campaignAccessDto'];
                 this.authenticationService.user.secondAdmin = JSON.parse(currentUser)['secondAdmin'];
                 this.referenceService.isUserProfileLoading = true;
                 this.getUserByUserName(userName);
@@ -290,7 +290,7 @@ export class AuthGuard implements CanActivate, CanActivateChild {
             const orgAdmin = roles.indexOf(this.roles.orgAdminRole) > -1;
             const isSuperAdmin = roles.indexOf(this.roles.superAdminRole) > -1;
             const isMarketing = roles.indexOf(this.roles.marketingRole) > -1;
-            let campaignAccessDto = this.authenticationService.user.campaignAccessDto;
+            let moduleAccessDto = this.authenticationService.user.moduleAccessDto;
             this.vanityUrlService.isVanityURLEnabled();
             if (isSuperAdmin) {
                 this.router.navigate(['/home/dashboard/admin-report']);
@@ -298,8 +298,8 @@ export class AuthGuard implements CanActivate, CanActivateChild {
             }
             if (urlType == this.formBaseUrl) {
                 let hasFormAccess = false;
-                if (campaignAccessDto != undefined) {
-                    hasFormAccess = campaignAccessDto.formBuilder;
+                if (moduleAccessDto != undefined) {
+                    hasFormAccess = moduleAccessDto.formBuilder;
                 }
                 let hasRole = roles.indexOf(this.roles.orgAdminRole) > -1 || roles.indexOf(this.roles.vendorRole) > -1
                     || roles.indexOf(this.roles.allRole) > -1 || roles.indexOf(this.roles.emailTemplateRole) > -1
@@ -344,9 +344,9 @@ export class AuthGuard implements CanActivate, CanActivateChild {
             else if (urlType == this.landingPagesUrl) {
                 let hasLandingPageAccess = false;
                 let partnerLandingPageAccess = false;
-                let campaignAccessDto = this.authenticationService.user.campaignAccessDto;
-                if (campaignAccessDto != undefined) {
-                    hasLandingPageAccess = campaignAccessDto.landingPage;
+                let moduleAccessDto = this.authenticationService.user.moduleAccessDto;
+                if (moduleAccessDto != undefined) {
+                    hasLandingPageAccess = moduleAccessDto.landingPage;
                 }
                 let hasRole = roles.indexOf(this.roles.orgAdminRole) > -1 || roles.indexOf(this.roles.vendorRole) > -1
                     || roles.indexOf(this.roles.allRole) > -1 || roles.indexOf(this.roles.emailTemplateRole) > -1

--- a/src/app/authentication/samlsecurityauth/samlsecurityauth.component.ts
+++ b/src/app/authentication/samlsecurityauth/samlsecurityauth.component.ts
@@ -107,7 +107,7 @@ export class SamlsecurityauthComponent implements OnInit {
         'expiresIn': this.authenticationService.expires_in,
         'hasCompany': res.hasCompany,
         'roles': res.roles,
-        'campaignAccessDto': res.campaignAccessDto,
+        'moduleAccessDto': res.moduleAccessDto || res.campaignAccessDto,
         'logedInCustomerCompanyNeme': res.companyName,
         'source': res.source
       };

--- a/src/app/campaigns/models/module-access.ts
+++ b/src/app/campaigns/models/module-access.ts
@@ -1,5 +1,5 @@
 import {DashboardType} from '../models/dashboard-type.enum';
-export class CampaignAccess {
+export class ModuleAccess {
   videoCampaign = false;
   emailCampaign = false
   socialCampaign = false;

--- a/src/app/contacts/add-contacts/add-contacts.component.ts
+++ b/src/app/contacts/add-contacts/add-contacts.component.ts
@@ -319,9 +319,9 @@ export class AddContactsComponent implements OnInit, OnDestroy {
         };
         this.parentInput = {};
         const currentUser = JSON.parse(localStorage.getItem('currentUser'));
-        let campaginAccessDto = currentUser.campaignAccessDto;
-        if (campaginAccessDto != undefined) {
-            this.companyId = campaginAccessDto.companyId;
+        let moduleAccessDto = currentUser.moduleAccessDto || currentUser.campaignAccessDto;
+        if (moduleAccessDto != undefined) {
+            this.companyId = moduleAccessDto.companyId;
         }
 
     }

--- a/src/app/contacts/contact-details/contact-details.component.ts
+++ b/src/app/contacts/contact-details/contact-details.component.ts
@@ -169,8 +169,8 @@ export class ContactDetailsComponent implements OnInit {
       this.vanityLoginDto.vanityUrlFilter = false;
     }
     const currentUser = localStorage.getItem('currentUser');
-		let campaginAccessDto = JSON.parse(currentUser)['campaignAccessDto'];
-		this.companyId = campaginAccessDto.companyId;
+                let moduleAccessDto = JSON.parse(currentUser)['moduleAccessDto'] || JSON.parse(currentUser)['campaignAccessDto'];
+                this.companyId = moduleAccessDto.companyId;
     this.gdprInput = {};
     this.isLocalhost = this.authenticationService.isLocalHost();
    }

--- a/src/app/contacts/edit-contacts/edit-contacts.component.ts
+++ b/src/app/contacts/edit-contacts/edit-contacts.component.ts
@@ -395,13 +395,13 @@ export class EditContactsComponent implements OnInit, OnDestroy {
 		this.loggedInUserId = this.authenticationService.getUserId();
 
 		this.parentInput = {};
-		const currentUser = localStorage.getItem('currentUser');
-		let campaginAccessDto = JSON.parse(currentUser)['campaignAccessDto'];
-		this.companyId = campaginAccessDto.companyId;
-		if (currentUrl.includes(RouterUrlConstants.home+RouterUrlConstants.contacts+RouterUrlConstants.company)) {
-			this.isFromCompanyModule = true;
-			this.manageCompanies = true;
-		}
+                const currentUser = localStorage.getItem('currentUser');
+                let moduleAccessDto = JSON.parse(currentUser)['moduleAccessDto'] || JSON.parse(currentUser)['campaignAccessDto'];
+                this.companyId = moduleAccessDto.companyId;
+                if (currentUrl.includes(RouterUrlConstants.home+RouterUrlConstants.contacts+RouterUrlConstants.company)) {
+                        this.isFromCompanyModule = true;
+                        this.manageCompanies = true;
+                }
 	}
 
 	onChangeAllContactUsers(event: Pagination) {

--- a/src/app/contacts/manage-contacts/manage-contacts.component.ts
+++ b/src/app/contacts/manage-contacts/manage-contacts.component.ts
@@ -394,11 +394,11 @@ export class ManageContactsComponent implements OnInit, AfterViewInit, AfterView
 		//this.loggedInUserId = this.authenticationService.getUserId();
 
 		this.parentInput = {};
-		const currentUser = localStorage.getItem('currentUser');
-		let campaginAccessDto = JSON.parse(currentUser)['campaignAccessDto'];
-		if (campaginAccessDto != undefined) {
-			this.companyId = campaginAccessDto.companyId;
-		}
+                const currentUser = localStorage.getItem('currentUser');
+                let moduleAccessDto = JSON.parse(currentUser)['moduleAccessDto'] || JSON.parse(currentUser)['campaignAccessDto'];
+                if (moduleAccessDto != undefined) {
+                        this.companyId = moduleAccessDto.companyId;
+                }
 		/**XNFR-836**/
 		if (currentUrl.includes(RouterUrlConstants.home+RouterUrlConstants.contacts+RouterUrlConstants.company)) {
 			this.isFromCompanyModule = true;

--- a/src/app/core/models/user.ts
+++ b/src/app/core/models/user.ts
@@ -1,5 +1,5 @@
 import { Role } from './role';
-import { CampaignAccess } from '../../campaigns/models/campaign-access';
+import { ModuleAccess } from '../../campaigns/models/module-access';
 import { CompanyProfileDTO } from '../../dashboard/company-profile/models/company-profile-dto';
 import { FlexiFieldsRequestAndResponseDto } from 'app/dashboard/models/flexi-fields-request-and-response-dto';
 
@@ -46,7 +46,7 @@ export class User {
     region: string = "";
     partnerType: string = "";
     category: string = "";
-    campaignAccessDto:CampaignAccess = new CampaignAccess();
+    moduleAccessDto: ModuleAccess = new ModuleAccess();
     legalBasis = [];
     legalBasisString = [];
 

--- a/src/app/core/services/authentication.service.ts
+++ b/src/app/core/services/authentication.service.ts
@@ -261,7 +261,7 @@ export class AuthenticationService {
             'expiresIn': this.map.expires_in,
             'hasCompany': res.json().hasCompany,
             'roles': res.json().roles,
-            'campaignAccessDto': res.json().campaignAccessDto,
+            'moduleAccessDto': res.json().moduleAccessDto || res.json().campaignAccessDto,
             'logedInCustomerCompanyNeme': res.json().companyName,
             'source': res.json().source,
             'userStatusCode': res.json().userStatusCode

--- a/src/app/core/services/reference.service.ts
+++ b/src/app/core/services/reference.service.ts
@@ -15,7 +15,7 @@ import { Timezone } from "../../core/models/timezone";
 import { Ng2DeviceService } from "ng2-device-detector";
 import { EmailTemplate } from "../../email-template/models/email-template";
 import { Campaign } from "../../campaigns/models/campaign";
-import { CampaignAccess } from "app/campaigns/models/campaign-access";
+import { ModuleAccess } from "app/campaigns/models/module-access";
 import { Properties } from "../../common/models/properties";
 import { CustomResponse } from "../../common/models/custom-response";
 import { User } from "../../core/models/user";
@@ -113,7 +113,7 @@ export class ReferenceService {
   selectedVideoLogodesc: string;
   contentManagementLoader: boolean;
   namesArray: any;
-  campaignAccess: CampaignAccess;
+  moduleAccess: ModuleAccess;
   manageRouter = false;
   detailViewIsLoading: boolean;
   videoCampaign = false;

--- a/src/app/core/services/util.service.ts
+++ b/src/app/core/services/util.service.ts
@@ -159,9 +159,9 @@ export class UtilService {
                 'expiresIn':  JSON.parse( currentUser )['expiresIn'],
                 'hasCompany': data.hasCompany,
                 'roles': data.roles,
-                'campaignAccessDto':data.campaignAccessDto,
+                'moduleAccessDto': data.moduleAccessDto || data.campaignAccessDto,
                 'logedInCustomerCompanyNeme':data.companyName,
-				'source':data.source,
+                                'source':data.source,
                 'secondAdmin': data.secondAdmin,
                 'isWelcomePageEnabled':JSON.parse( currentUser )[XAMPLIFY_CONSTANTS.welcomePageEnabledKey],
             };

--- a/src/app/dashboard/admin-partner-companies/admin-partner-companies.component.html
+++ b/src/app/dashboard/admin-partner-companies/admin-partner-companies.component.html
@@ -131,17 +131,17 @@
               <tbody>
                 <tr>
                   <th scope="row">Login As Team Member</th>
-                  <td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.loginAsTeamMember"
+                  <td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.loginAsTeamMember"
                       [ngModelOptions]="{standalone: true}"></td>
                 </tr>
                 <tr>
                   <th scope="row">Exclude Users/Domains</th>
-                  <td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.excludeUsersOrDomains"
+                  <td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.excludeUsersOrDomains"
                       [ngModelOptions]="{standalone: true}"></td>
                 </tr>
                 <tr>
                   <th scope="row">Non Vanity Access</th>
-                  <td><input class="checkBox_shadow" type="checkbox" [checked]="campaignAccess.nonVanityAccessEnabled"
+                  <td><input class="checkBox_shadow" type="checkbox" [checked]="moduleAccess.nonVanityAccessEnabled"
                        (change)="onNonVanityAccessToggle($event)"></td>
                 </tr>
                 <tr>
@@ -155,11 +155,11 @@
                     </a>
                   </th>
                   <td style="width: 50%;">
-                    <select class="form-control" id="maxAdmins-partners-Edit" [(ngModel)]="campaignAccess.maxAdmins" (change)="setMaxAdmins()">
-                      <option value="2" [selected]="campaignAccess.maxAdmins ==2">2</option>
-                      <option value="3" [selected]="campaignAccess.maxAdmins ==3">3</option>
-                      <option value="4" [selected]="campaignAccess.maxAdmins ==4">4</option>
-                      <option value="5" [selected]="campaignAccess.maxAdmins ==5">5</option>
+                    <select class="form-control" id="maxAdmins-partners-Edit" [(ngModel)]="moduleAccess.maxAdmins" (change)="setMaxAdmins()">
+                      <option value="2" [selected]="moduleAccess.maxAdmins ==2">2</option>
+                      <option value="3" [selected]="moduleAccess.maxAdmins ==3">3</option>
+                      <option value="4" [selected]="moduleAccess.maxAdmins ==4">4</option>
+                      <option value="5" [selected]="moduleAccess.maxAdmins ==5">5</option>
                     </select>
                   </td>
                 </tr>

--- a/src/app/dashboard/admin-partner-companies/admin-partner-companies.component.ts
+++ b/src/app/dashboard/admin-partner-companies/admin-partner-companies.component.ts
@@ -10,7 +10,7 @@ import { Router } from '@angular/router';
 import { SortOption } from '../../core/models/sort-option';
 import { XtremandLogger } from '../../error-pages/xtremand-logger.service';
 import { UtilService } from '../../core/services/util.service';
-import { CampaignAccess } from 'app/campaigns/models/campaign-access';
+import { ModuleAccess } from 'app/campaigns/models/module-access';
 import { AnalyticsCountDto } from 'app/core/models/analytics-count-dto';
 
 declare var $,swal: any;
@@ -30,7 +30,7 @@ export class AdminPartnerCompaniesComponent implements OnInit {
 	selectedPartnerCompany:any;
 	dnsConfigured = false;
 	modalPopupLoader = false;
-	campaignAccess:CampaignAccess = new CampaignAccess();
+        moduleAccess: ModuleAccess = new ModuleAccess();
 	analyticsCountDto: any;
 	constructor(public dashboardService: DashboardService, public referenceService: ReferenceService,
 		public httpRequestLoader: HttpRequestLoader,
@@ -127,8 +127,8 @@ export class AdminPartnerCompaniesComponent implements OnInit {
 
 	  updateModules(partnerCompany:any){
 		this.modalPopupLoader = true;
-		this.campaignAccess.companyId = partnerCompany.companyId;
-		this.dashboardService.updatePartnerModuleAccess(this.campaignAccess).
+		this.moduleAccess.companyId = partnerCompany.companyId;
+		this.dashboardService.updatePartnerModuleAccess(this.moduleAccess).
 		subscribe(result => {
 		  this.modalPopupLoader = false;
 		  if(result.statusCode==200){
@@ -147,7 +147,7 @@ export class AdminPartnerCompaniesComponent implements OnInit {
 	  /** XNFR-139 ***** */
   setMaxAdmins(){
     let maxAdmins =  $('#maxAdmins-partners-Edit option:selected').val();
-    this.campaignAccess.maxAdmins = maxAdmins;
+    this.moduleAccess.maxAdmins = maxAdmins;
 }
 
 findMaximumAdminsLimitDetails(partnerCompany:any){
@@ -165,10 +165,10 @@ findMaximumAdminsLimitDetails(partnerCompany:any){
 	  },()=>{
 		this.selectedPartnerCompany = partnerCompany;
 		this.dnsConfigured = partnerCompany.emailDnsConfigured;
-		this.campaignAccess.loginAsTeamMember = partnerCompany.loginAsTeamMember;
-		this.campaignAccess.excludeUsersOrDomains = partnerCompany.excludeUsersOrDomains;
-		this.campaignAccess.maxAdmins = partnerCompany.maxAdmins;
-		this.campaignAccess.nonVanityAccessEnabled =  partnerCompany.nonVanityAccessEnabled;
+		this.moduleAccess.loginAsTeamMember = partnerCompany.loginAsTeamMember;
+		this.moduleAccess.excludeUsersOrDomains = partnerCompany.excludeUsersOrDomains;
+		this.moduleAccess.maxAdmins = partnerCompany.maxAdmins;
+		this.moduleAccess.nonVanityAccessEnabled =  partnerCompany.nonVanityAccessEnabled;
 	  }
 	);
   }
@@ -187,7 +187,7 @@ onNonVanityAccessToggle(event: Event) {
     cancelButtonColor: '#999',
     confirmButtonText: `Yes, ${actionText} it!`
   }).then(() => {
-    this.campaignAccess.nonVanityAccessEnabled = newValue;
+    this.moduleAccess.nonVanityAccessEnabled = newValue;
   }, (dismiss: any) => {
     (event.target as HTMLInputElement).checked = !newValue;
   });

--- a/src/app/dashboard/company-profile/edit-company-profile/edit-company-profile.component.html
+++ b/src/app/dashboard/company-profile/edit-company-profile/edit-company-profile.component.html
@@ -178,156 +178,156 @@
 												<ng-container *ngIf="!prm">
 													<tr>
 														<th scope="col">Sales Enablement (View In Browser In Create	Campaign)</th>
-														<td><input type="checkbox"[(ngModel)]="campaignAccess.salesEnablement" [ngModelOptions]="{standalone: true}"></td>
+														<td><input type="checkbox"[(ngModel)]="moduleAccess.salesEnablement" [ngModelOptions]="{standalone: true}"></td>
 													</tr>
 													<tr>
 														<th scope="col">Data Share</th>
-														<td><input type="checkbox" [(ngModel)]="campaignAccess.dataShare"[ngModelOptions]="{standalone: true}"></td>
+														<td><input type="checkbox" [(ngModel)]="moduleAccess.dataShare"[ngModelOptions]="{standalone: true}"></td>
 													</tr>
 													<tr>
 														<th scope="col">Email Campaign</th>
-														<td><input type="checkbox" [(ngModel)]="campaignAccess.emailCampaign" [ngModelOptions]="{standalone: true}"></td>
+														<td><input type="checkbox" [(ngModel)]="moduleAccess.emailCampaign" [ngModelOptions]="{standalone: true}"></td>
 													</tr>
 													<tr>
 														<th scope="col">Video Campaign</th>
-														<td><input type="checkbox" [(ngModel)]="campaignAccess.videoCampaign" [ngModelOptions]="{standalone: true}"></td>
+														<td><input type="checkbox" [(ngModel)]="moduleAccess.videoCampaign" [ngModelOptions]="{standalone: true}"></td>
 													</tr>
 													<tr>
 														<th scope="col">Social Campaign</th>
-														<td><input type="checkbox" [(ngModel)]="campaignAccess.socialCampaign" [ngModelOptions]="{standalone: true}"></td>
+														<td><input type="checkbox" [(ngModel)]="moduleAccess.socialCampaign" [ngModelOptions]="{standalone: true}"></td>
 													</tr>
 													<tr>
 														<th scope="col">Event Campaign</th>
-														<td><input type="checkbox" [(ngModel)]="campaignAccess.eventCampaign" [ngModelOptions]="{standalone: true}"></td>
+														<td><input type="checkbox" [(ngModel)]="moduleAccess.eventCampaign" [ngModelOptions]="{standalone: true}"></td>
 													</tr>
 													<tr>
 														<th scope="col">Survey Campaign</th>
-														<td><input type="checkbox" [(ngModel)]="campaignAccess.survey" [ngModelOptions]="{standalone: true}"></td>
+														<td><input type="checkbox" [(ngModel)]="moduleAccess.survey" [ngModelOptions]="{standalone: true}"></td>
 													</tr>
 													<tr>
 														<th scope="col">Form Builder</th>
-														<td><input type="checkbox" [(ngModel)]="campaignAccess.formBuilder" [ngModelOptions]="{standalone: true}"></td>
+														<td><input type="checkbox" [(ngModel)]="moduleAccess.formBuilder" [ngModelOptions]="{standalone: true}"></td>
 													</tr>
 													<tr>
 														<th scope="col">Page</th>
-														<td><input type="checkbox" [(ngModel)]="campaignAccess.landingPage" [ngModelOptions]="{standalone: true}"></td>
+														<td><input type="checkbox" [(ngModel)]="moduleAccess.landingPage" [ngModelOptions]="{standalone: true}"></td>
 													</tr>
 													<tr>
 														<th scope="col">Page Campaign</th>
-														<td><input type="checkbox" [(ngModel)]="campaignAccess.landingPageCampaign" [ngModelOptions]="{standalone: true}"></td>
+														<td><input type="checkbox" [(ngModel)]="moduleAccess.landingPageCampaign" [ngModelOptions]="{standalone: true}"></td>
 													</tr>
 
-													<tr *ngIf="campaignAccess?.shareLeads">
+													<tr *ngIf="moduleAccess?.shareLeads">
 														<th scope="col">One-Click Launch</th>
 														<td>
-															<input type="checkbox" [(ngModel)]="campaignAccess.oneClickLaunch" [ngModelOptions]="{standalone: true}">
+															<input type="checkbox" [(ngModel)]="moduleAccess.oneClickLaunch" [ngModelOptions]="{standalone: true}">
 														</td>
 													</tr>
 													<tr>
 														<th scope="col">Partner Template Opened Tracking Analytics</th>
-														<td><input type="checkbox" [(ngModel)]="campaignAccess.campaignPartnerTemplateOpenedAnalytics" [ngModelOptions]="{standalone: true}"></td>
+														<td><input type="checkbox" [(ngModel)]="moduleAccess.campaignPartnerTemplateOpenedAnalytics" [ngModelOptions]="{standalone: true}"></td>
 													</tr>
 													<!--Refer Vendor-->
 													<tr>
 														<th scope="row">{{properties?.inviteAVendor}} (Option Applicable For Vanity Url)</th>
 														<td class="pt0">
-															<app-custom-ui-switch [customSwitch]="campaignAccess.referVendor" (customUiSwitchEventEmitter)="setReferVendorValue($event)"></app-custom-ui-switch>
+															<app-custom-ui-switch [customSwitch]="moduleAccess.referVendor" (customUiSwitchEventEmitter)="setReferVendorValue($event)"></app-custom-ui-switch>
 														</td>
 													</tr>
 												</ng-container>
 												<tr>
 													<th scope="row">SSO Enabled</th>
 													<td class="pt0">
-														<app-custom-ui-switch [customSwitch]="campaignAccess.ssoEnabled" (customUiSwitchEventEmitter)="setSSOValue($event)"></app-custom-ui-switch>
+														<app-custom-ui-switch [customSwitch]="moduleAccess.ssoEnabled" (customUiSwitchEventEmitter)="setSSOValue($event)"></app-custom-ui-switch>
 													</td>
 												</tr>
 												<tr>
 													<th scope="col">Share Leads</th>
 													<td>
 														<input type="checkbox" id="share-leads-c"
-															[(ngModel)]="campaignAccess.shareLeads"
+															[(ngModel)]="moduleAccess.shareLeads"
 															[ngModelOptions]="{standalone: true}"
 															(click)="updateOneClickLaunchOption()">
 													</td>
 												</tr>
 												<tr>
 													<th scope="col">Leads (Opportunities)</th>
-													<td><input type="checkbox" [(ngModel)]="campaignAccess.leads"
+													<td><input type="checkbox" [(ngModel)]="moduleAccess.leads"
 															[ngModelOptions]="{standalone: true}"></td>
 												</tr>
 												<tr>
 													<th scope="row">Login As Team Member</th>
 													<td><input type="checkbox"
-															[(ngModel)]="campaignAccess.loginAsTeamMember"
+															[(ngModel)]="moduleAccess.loginAsTeamMember"
 															[ngModelOptions]="{standalone: true}"></td>
 												</tr>
 												<tr>
 													<th scope="col">Vanity URL</th>
-													<td><input type="checkbox" [(ngModel)]="campaignAccess.vanityUrlDomain" 
+													<td><input type="checkbox" [(ngModel)]="moduleAccess.vanityUrlDomain" 
 														[ngModelOptions]="{standalone: true}" (change)="onVanityUrlChange()"></td>
 												</tr>
 												<tr *ngIf="vendor || orgAdmin">
 													<th scope="col">Enable Marketing Modules</th>
-													<td><input type="checkbox" [(ngModel)]="campaignAccess.marketingModulesEnabled"
-															[ngModelOptions]="{standalone: true}" [disabled]="!campaignAccess.vanityUrlDomain"></td>
+													<td><input type="checkbox" [(ngModel)]="moduleAccess.marketingModulesEnabled"
+															[ngModelOptions]="{standalone: true}" [disabled]="!moduleAccess.vanityUrlDomain"></td>
 												</tr>
 												<tr>
 													<th scope="col">MDF</th>
-													<td><input type="checkbox" [(ngModel)]="campaignAccess.mdf"
+													<td><input type="checkbox" [(ngModel)]="moduleAccess.mdf"
 															[ngModelOptions]="{standalone: true}"></td>
 												</tr>
 												<tr>
 													<th scope="row">Social Feeds</th>
-													<td><input type="checkbox" [(ngModel)]="campaignAccess.rssFeeds"
+													<td><input type="checkbox" [(ngModel)]="moduleAccess.rssFeeds"
 															[ngModelOptions]="{standalone: true}"></td>
 												</tr>
 												<tr>
 													<th scope="row">Social Share</th>
-													<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.socialShareOptionEnabled"
+													<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.socialShareOptionEnabled"
 															[ngModelOptions]="{standalone: true}"></td>
 												</tr>
 												<tr>
 													<th scope="col">DAM</th>
-													<td><input type="checkbox" [(ngModel)]="campaignAccess.dam"
+													<td><input type="checkbox" [(ngModel)]="moduleAccess.dam"
 															id="damCheckBoxC" [ngModelOptions]="{standalone: true}"
 															(click)="updateLmsAndPlayBooks()"></td>
 												</tr>
-												<ng-container *ngIf="campaignAccess.dam">
+												<ng-container *ngIf="moduleAccess.dam">
 													<tr>
 														<th scope="col">LMS</th>
-														<td><input type="checkbox" [(ngModel)]="campaignAccess.lms"
+														<td><input type="checkbox" [(ngModel)]="moduleAccess.lms"
 																[ngModelOptions]="{standalone: true}"></td>
 													</tr>
 													<tr>
 														<th scope="col">PlayBooks</th>
 														<td><input type="checkbox"
-																[(ngModel)]="campaignAccess.playbooks"
+																[(ngModel)]="moduleAccess.playbooks"
 																[ngModelOptions]="{standalone: true}"></td>
 													</tr>
 												</ng-container>
 												<tr>
 													<th scope="row">Exclude Users/Domains</th>
 													<td><input type="checkbox"
-															[(ngModel)]="campaignAccess.excludeUsersOrDomains"
+															[(ngModel)]="moduleAccess.excludeUsersOrDomains"
 															[ngModelOptions]="{standalone: true}"></td>
 												</tr>
 												<tr>
 													<th scope="row">Chat Support</th>
-													<td><input type="checkbox" [(ngModel)]="campaignAccess.chatSupport"
+													<td><input type="checkbox" [(ngModel)]="moduleAccess.chatSupport"
 															[ngModelOptions]="{standalone: true}"></td>
 												</tr>
 												<!-- XNFR-134 -->
 												<tr>
 													<th scope="row">Custom Skin Settings</th>
 													<td><input type="checkbox"
-															[(ngModel)]="campaignAccess.customSkinSettings"
+															[(ngModel)]="moduleAccess.customSkinSettings"
 															[ngModelOptions]="{standalone: true}"></td>
 												</tr>
 												<!-- XNFR-224 -->
 												<tr *ngIf="!marketing">
 													<th scope="row">Login As Partner</th>
 													<td><input type="checkbox"
-															[(ngModel)]="campaignAccess.loginAsPartner"
+															[(ngModel)]="moduleAccess.loginAsPartner"
 															[ngModelOptions]="{standalone: true}"></td>
 												</tr>
 
@@ -335,7 +335,7 @@
 												<tr>
 													<th scope="row">Microsoft SSO</th>
 													<td>
-														<input type="checkbox" [(ngModel)]="campaignAccess.microsoftSSO"
+														<input type="checkbox" [(ngModel)]="moduleAccess.microsoftSSO"
 															[ngModelOptions]="{standalone: true}">
 													</td>
 
@@ -343,61 +343,61 @@
 												<tr *ngIf="!marketing">
 													<th scope="row">Share White Labeled Content</th>
 													<td><input type="checkbox"
-															[(ngModel)]="campaignAccess.shareWhiteLabeledContent"
+															[(ngModel)]="moduleAccess.shareWhiteLabeledContent"
 															[ngModelOptions]="{standalone: true}"></td>
 												</tr>
 												<!--XNFR-381-->
 												<tr *ngIf="!marketing">
 													<th scope="row">Create Workflow (Partner Journey)</th>
 													<td><input type="checkbox"
-															[(ngModel)]="campaignAccess.createWorkflow"
+															[(ngModel)]="moduleAccess.createWorkflow"
 															[ngModelOptions]="{standalone: true}"></td>
 												</tr>
 												<!--XNFR-428-->
 												<tr *ngIf="!marketing">
 													<th scope="row">Vendor Journey</th>
-													<td><input type="checkbox"[(ngModel)]="campaignAccess.vendorJourney" [ngModelOptions]="{standalone: true}"></td>
+													<td><input type="checkbox"[(ngModel)]="moduleAccess.vendorJourney" [ngModelOptions]="{standalone: true}"></td>
 												</tr>
 												<!--XNFR-595-->
 												<tr>
 													<th scope="row">Payment Overdue</th>
 													<td class="pt0">
-														<app-custom-ui-switch [customSwitch]="campaignAccess.paymentOverDue" (customUiSwitchEventEmitter)="customUiSwitchEventReceiver($event)"></app-custom-ui-switch>
+														<app-custom-ui-switch [customSwitch]="moduleAccess.paymentOverDue" (customUiSwitchEventEmitter)="customUiSwitchEventReceiver($event)"></app-custom-ui-switch>
 													</td>
 												</tr>
 												<!--XNFR-595-->
 												<tr>
 													<th scope="row">Welcome Page</th>
-													<td><input type="checkbox" [(ngModel)]="campaignAccess.welcomePages" [ngModelOptions]="{standalone: true}"></td>
+													<td><input type="checkbox" [(ngModel)]="moduleAccess.welcomePages" [ngModelOptions]="{standalone: true}"></td>
 												</tr>
 												<!--XNFR-820-->
 												<tr>
 													<th scope="row">Approval Hub</th>
-													<td><input type="checkbox" [(ngModel)]="campaignAccess.approvalHub" [ngModelOptions]="{standalone: true}"></td>
+													<td><input type="checkbox" [(ngModel)]="moduleAccess.approvalHub" [ngModelOptions]="{standalone: true}"></td>
 												</tr>
 												<!--XNFR-979-->
 												<tr>
 													<th scope="row">Insights</th>
-													<td><input type="checkbox" [(ngModel)]="campaignAccess.insights" [ngModelOptions]="{standalone: true}"></td>
+													<td><input type="checkbox" [(ngModel)]="moduleAccess.insights" [ngModelOptions]="{standalone: true}"></td>
 												</tr>
 
 												<!--XNFR-1062-->
 												<tr>
 													<th scope="row">Mail Integration</th>
-													<td><input type="checkbox" [(ngModel)]="campaignAccess.mailsEnabled" [ngModelOptions]="{standalone: true}"></td>
+													<td><input type="checkbox" [(ngModel)]="moduleAccess.mailsEnabled" [ngModelOptions]="{standalone: true}"></td>
 												</tr>
 												<!--XNFR-832-->
 												<tr *ngIf="marketing || orgAdmin">
 													<th scope="row">Unlock MDF Funding</th>
 													<td class="pt0">
-														<app-custom-ui-switch [customSwitch]="campaignAccess.unlockMdfFundingEnabled" (customUiSwitchEventEmitter)="unlockMdfFundingUiSwitchEventReceiver($event)"></app-custom-ui-switch>
+														<app-custom-ui-switch [customSwitch]="moduleAccess.unlockMdfFundingEnabled" (customUiSwitchEventEmitter)="unlockMdfFundingUiSwitchEventReceiver($event)"></app-custom-ui-switch>
 													</td>
 												</tr>
 												<!--XNFR-878-->
 												<tr *ngIf="!marketing">
 													<th scope="row">Allow Vendor to Change Partner Primary Admin</th>
 													<td class="pt0">
-														<app-custom-ui-switch [customSwitch]="campaignAccess.allowVendorToChangePartnerPrimaryAdmin" (customUiSwitchEventEmitter)="allowVendorToChangePartnerPrimaryAdminUiSwitchEventReceiver($event)"></app-custom-ui-switch>
+														<app-custom-ui-switch [customSwitch]="moduleAccess.allowVendorToChangePartnerPrimaryAdmin" (customUiSwitchEventEmitter)="allowVendorToChangePartnerPrimaryAdminUiSwitchEventReceiver($event)"></app-custom-ui-switch>
 													</td>
 												</tr>
 												<tr>
@@ -405,7 +405,7 @@
 														<img src="assets/images/oliverAiLogo.svg" alt="Oliver Icon" width="22px" height="22px">
 													</th>
 														<td>
-															<app-custom-ui-switch [customSwitch]="campaignAccess.oliverActive"
+															<app-custom-ui-switch [customSwitch]="moduleAccess.oliverActive"
 																(customUiSwitchEventEmitter)="oliverActiveUiSwitchEventReceiver($event)"></app-custom-ui-switch>
 															<div style="margin-left: 20px; margin-top: 10px;">
 																
@@ -420,34 +420,34 @@
 																<div>
 																	<strong>
 																		<input class="checkBox_shadow" type="checkbox" [disabled]="disableOliverAgentModuleOptions"
-																			[(ngModel)]="campaignAccess.oliverInsightsEnabled" [ngModelOptions]="{standalone: true}">
+																			[(ngModel)]="moduleAccess.oliverInsightsEnabled" [ngModelOptions]="{standalone: true}">
 																		<span class="ml10">Enable Oliver Insights</span>
 																	</strong>
 																</div>
 																<div>
 																	<strong>
-																		<input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.brainstormWithOliverEnabled"
+																		<input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.brainstormWithOliverEnabled"
 																			[ngModelOptions]="{standalone: true}" [disabled]="disableOliverAgentModuleOptions">
 																		<span class="ml10">Enable Brainstorm With Oliver</span>
 																	</strong>
 																</div>
 																<div>
 																	<strong>
-																		<input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.oliverSparkWriterEnabled"
+																		<input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.oliverSparkWriterEnabled"
 																			[ngModelOptions]="{standalone: true}" [disabled]="disableOliverAgentModuleOptions">
 																		<span class="ml10">Enable Oliver Spark Writer</span>
 																	</strong>
 																</div>
 																<div>
 																	<strong>
-																		<input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.oliverParaphraserEnabled"
+																		<input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.oliverParaphraserEnabled"
 																			[ngModelOptions]="{standalone: true}" [disabled]="disableOliverAgentModuleOptions">
 																		<span class="ml10">Enable Oliver Paraphraser</span>
 																	</strong>
 																</div>
 																<div>
 																	<strong>
-																		<input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.oliverContactAgentEnabled"
+																		<input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.oliverContactAgentEnabled"
 																			[ngModelOptions]="{standalone: true}" [disabled]="disableOliverAgentModuleOptions">
 																		<span class="ml10">Enable Oliver Contact Agent</span>
 																	</strong>
@@ -455,7 +455,7 @@
 
 																<div>
 																	<strong>
-																		<input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.oliverPartnerAgentEnabled"
+																		<input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.oliverPartnerAgentEnabled"
 																			[ngModelOptions]="{standalone: true}" [disabled]="disableOliverAgentModuleOptions">
 																		<span class="ml10">Enable Oliver Partner Agent</span>
 																	</strong>
@@ -463,7 +463,7 @@
 
 																<div>
 																	<strong>
-																		<input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.oliverCampaignAgentEnabled"
+																		<input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.oliverCampaignAgentEnabled"
 																			[ngModelOptions]="{standalone: true}" [disabled]="disableOliverAgentModuleOptions">
 																		<span class="ml10">Enable Oliver Campaign Agent</span>
 																	</strong>
@@ -476,16 +476,16 @@
 												<tr *ngIf="!prm">
 													<th scope="row"> Contact Limit </th>
 													<td class="pt0">
-														<app-custom-ui-switch [customSwitch]="campaignAccess.contactSubscriptionLimitEnabled"
+														<app-custom-ui-switch [customSwitch]="moduleAccess.contactSubscriptionLimitEnabled"
 															(customUiSwitchEventEmitter)="contactUploadQuotaEnabledUiSwitchEventReceiver($event)"></app-custom-ui-switch>
 														<div style="padding-left: 5px;">
 															<span class="required"><Strong>*</Strong></span>
 															<strong>Contact Limit: </strong>
 															<input [disabled]="disableContactSubscriptionLimitField" type="number"
-																[(ngModel)]="campaignAccess.contactSubscriptionLimit" [ngModelOptions]="{standalone: true}"
+																[(ngModel)]="moduleAccess.contactSubscriptionLimit" [ngModelOptions]="{standalone: true}"
 																class="form-control" name="contactSubscriptionLimit" placeholder="Enter Limit Here" min="1"
 																oninput="validity.valid||(value='');"
-																(input)="contactUploadQuotaLimitChange(campaignAccess.contactSubscriptionLimit)">
+																(input)="contactUploadQuotaLimitChange(moduleAccess.contactSubscriptionLimit)">
 														</div>
 													</td>
 												</tr>

--- a/src/app/dashboard/company-profile/edit-company-profile/edit-company-profile.component.ts
+++ b/src/app/dashboard/company-profile/edit-company-profile/edit-company-profile.component.ts
@@ -27,7 +27,7 @@ import { UtilService } from 'app/core/services/util.service';
 // ImageCroppedEvent
 import { ImageCroppedEvent } from '../../../common/image-cropper/interfaces/image-cropped-event.interface';
 import { ImageCropperComponent } from '../../../common/image-cropper/component/image-cropper.component';
-import { CampaignAccess } from '../../../campaigns/models/campaign-access';
+import { ModuleAccess } from '../../../campaigns/models/module-access';
 import { CallActionSwitch } from '../../../videos/models/call-action-switch';
 import { VanityURLService } from 'app/vanity-url/services/vanity.url.service';
 import { MdfService } from 'app/mdf/services/mdf.service';
@@ -47,11 +47,11 @@ declare var $,swal: any;
     templateUrl: './edit-company-profile.component.html',
     styleUrls: ['./edit-company-profile.component.css', '../../../../assets/global/plugins/bootstrap-fileinput/bootstrap-fileinput.css',
                 '../../../../assets/css/phone-number-plugin.css'],
-    providers: [Processor, CountryNames, RegularExpressions, Properties,CampaignAccess,CallActionSwitch,MdfService]
+    providers: [Processor, CountryNames, RegularExpressions, Properties,ModuleAccess,CallActionSwitch,MdfService]
 
 })
 export class EditCompanyProfileComponent implements OnInit, OnDestroy, AfterViewInit {
-    campaignAccess = new CampaignAccess();
+    moduleAccess = new ModuleAccess();
     upgradeToVendor: boolean;
     createAccount: boolean;
     customResponse: CustomResponse = new CustomResponse();
@@ -252,9 +252,9 @@ export class EditCompanyProfileComponent implements OnInit, OnDestroy, AfterView
                 this.validatePattern('userEmailId');
                 this.validateUserUsingEmailId();
             }
-            this.campaignAccess.emailCampaign = true;
-            this.campaignAccess.videoCampaign = true;
-            this.campaignAccess.socialCampaign = true;
+            this.moduleAccess.emailCampaign = true;
+            this.moduleAccess.videoCampaign = true;
+            this.moduleAccess.socialCampaign = true;
             this.isFromAdminPanel = true;
             this.addBlur();
             // Debounce search.
@@ -668,7 +668,7 @@ export class EditCompanyProfileComponent implements OnInit, OnDestroy, AfterView
                             'expiresIn': JSON.parse(currentUser)['expiresIn'],
                             'hasCompany': data.hasCompany,
                             'roles': data.roles,
-                            'campaignAccessDto': data.campaignAccessDto,
+                            'moduleAccessDto': data.moduleAccessDto || data.campaignAccessDto,
                             'logedInCustomerCompanyNeme': JSON.parse(currentUser)['companyName'],
                             'source': data.source,
                             'isWelcomePageEnabled': JSON.parse(currentUser)[XAMPLIFY_CONSTANTS.welcomePageEnabledKey]
@@ -758,7 +758,7 @@ export class EditCompanyProfileComponent implements OnInit, OnDestroy, AfterView
                             'expiresIn': JSON.parse(currentUser)['expiresIn'],
                             'hasCompany': self.authenticationService.user.hasCompany,
                             'roles': JSON.parse(currentUser)['roles'],
-                            'campaignAccessDto': JSON.parse(currentUser)['campaignAccessDto'],
+                            'moduleAccessDto': JSON.parse(currentUser)['moduleAccessDto'] || JSON.parse(currentUser)['campaignAccessDto'],
                             'logedInCustomerCompanyNeme': companyName,
                             'source': JSON.parse(currentUser)['source'],
                             'isWelcomePageEnabled': JSON.parse(currentUser)[XAMPLIFY_CONSTANTS.welcomePageEnabledKey]
@@ -1715,7 +1715,7 @@ export class EditCompanyProfileComponent implements OnInit, OnDestroy, AfterView
                && !this.facebookLinkError && !this.googlePlusLinkError && !this.twitterLinkError && !this.linkedinLinkError && !this.cityError && !this.stateError && !this.countryError &&
                !this.zipError && !this.logoError && !this.aboutUsError) {
                this.customResponse = new CustomResponse();
-               this.companyProfile.campaignAccessDto = this.campaignAccess;
+               this.companyProfile.moduleAccessDto = this.moduleAccess;
                this.companyProfile.roleId = $('#selectedRole option:selected').val();
                this.companyProfileService.createNewVendorRole(this.companyProfile)
                .subscribe(
@@ -1726,7 +1726,7 @@ export class EditCompanyProfileComponent implements OnInit, OnDestroy, AfterView
                     this.refService.showSweetAlertErrorMessage("Please Upload Company Logo");
                     this.refService.goToTop();
                    }else{
-                    if(this.campaignAccess.mdf){
+                    if(this.moduleAccess.mdf){
                         this.mdfService.saveMdfRequestForm(this.companyProfile.userEmailId, this.companyProfile.companyProfileName).subscribe((result :any)=> {
                             if (result.access) {
                                 if (result.statusCode === 100) {
@@ -1762,8 +1762,8 @@ export class EditCompanyProfileComponent implements OnInit, OnDestroy, AfterView
            }
         
        }else{
-           this.campaignAccess.userId = this.userId;
-           this.companyProfileService.upgradeToVendorRole(this.campaignAccess)
+           this.moduleAccess.userId = this.userId;
+           this.companyProfileService.upgradeToVendorRole(this.moduleAccess)
            .subscribe(
            (result:any) => {
               this.goBackToAdminPanel(result.message);
@@ -1809,7 +1809,7 @@ export class EditCompanyProfileComponent implements OnInit, OnDestroy, AfterView
    }
    
    setVendorTier1(event:any){
-       //this.campaignAccess.vendorTier1 = event;
+       //this.moduleAccess.vendorTier1 = event;
    }
 
     setVendorLogoEnabled(event: any) {
@@ -1940,47 +1940,47 @@ export class EditCompanyProfileComponent implements OnInit, OnDestroy, AfterView
           this.orgAdmin = roleId==2;
           this.vendor = roleId==13;
           if(this.prm){
-            this.campaignAccess.emailCampaign = false;
-            this.campaignAccess.videoCampaign = false;
-            this.campaignAccess.videoCampaign = false;
-            this.campaignAccess.socialCampaign = false;
-            this.campaignAccess.eventCampaign = false;
-            this.campaignAccess.survey = false;
-            this.campaignAccess.formBuilder = true;
-            this.campaignAccess.landingPage = false;
-            this.campaignAccess.landingPageCampaign = false;
-            this.campaignAccess.shareLeads = false;
-            this.campaignAccess.allBoundSource = false;
-            this.campaignAccess.campaignPartnerTemplateOpenedAnalytics = false;
-            this.campaignAccess.salesEnablement = false;
-            this.campaignAccess.dataShare = false;
-            this.campaignAccess.oneClickLaunch = false;
-            this.campaignAccess.referVendor = false;
-            this.campaignAccess.ssoEnabled = false;
-            this.campaignAccess.unlockMdfFundingEnabled = false;
+            this.moduleAccess.emailCampaign = false;
+            this.moduleAccess.videoCampaign = false;
+            this.moduleAccess.videoCampaign = false;
+            this.moduleAccess.socialCampaign = false;
+            this.moduleAccess.eventCampaign = false;
+            this.moduleAccess.survey = false;
+            this.moduleAccess.formBuilder = true;
+            this.moduleAccess.landingPage = false;
+            this.moduleAccess.landingPageCampaign = false;
+            this.moduleAccess.shareLeads = false;
+            this.moduleAccess.allBoundSource = false;
+            this.moduleAccess.campaignPartnerTemplateOpenedAnalytics = false;
+            this.moduleAccess.salesEnablement = false;
+            this.moduleAccess.dataShare = false;
+            this.moduleAccess.oneClickLaunch = false;
+            this.moduleAccess.referVendor = false;
+            this.moduleAccess.ssoEnabled = false;
+            this.moduleAccess.unlockMdfFundingEnabled = false;
           }else if(this.marketing){
-              this.campaignAccess.loginAsPartner = false;
-              this.campaignAccess.shareWhiteLabeledContent = false;
-              this.campaignAccess.createWorkflow = false;
+              this.moduleAccess.loginAsPartner = false;
+              this.moduleAccess.shareWhiteLabeledContent = false;
+              this.moduleAccess.createWorkflow = false;
           }
       }
 
       selectDashboardType(){
         let selectedDashboard = $('#dashboardTypeC option:selected').val();
         if(selectedDashboard==DashboardType[DashboardType.DASHBOARD]){
-          this.campaignAccess.dashboardType = DashboardType.DASHBOARD;
+          this.moduleAccess.dashboardType = DashboardType.DASHBOARD;
         }else if(selectedDashboard==DashboardType[DashboardType.ADVANCED_DASHBOARD]){
-          this.campaignAccess.dashboardType = DashboardType.ADVANCED_DASHBOARD;
+          this.moduleAccess.dashboardType = DashboardType.ADVANCED_DASHBOARD;
         }else if(selectedDashboard==DashboardType[DashboardType.DETAILED_DASHBOARD]){
-          this.campaignAccess.dashboardType = DashboardType.DETAILED_DASHBOARD;
+          this.moduleAccess.dashboardType = DashboardType.DETAILED_DASHBOARD;
         }
       }
 
       updateLmsAndPlayBooks(){
       let isDamChecked = $('#damCheckBoxC').is(':checked');
           if(!isDamChecked){
-              this.campaignAccess.lms = false;
-              this.campaignAccess.playbooks = false;
+              this.moduleAccess.lms = false;
+              this.moduleAccess.playbooks = false;
           }
       }
 
@@ -1988,7 +1988,7 @@ export class EditCompanyProfileComponent implements OnInit, OnDestroy, AfterView
       updateOneClickLaunchOption(){
         let isShareLeadsChecked = $('#share-leads-c').is(':checked');
         if(!isShareLeadsChecked){
-            this.campaignAccess.oneClickLaunch = false;
+            this.moduleAccess.oneClickLaunch = false;
         }
       }
       /** XNFR-134 ***** */
@@ -1999,7 +1999,7 @@ export class EditCompanyProfileComponent implements OnInit, OnDestroy, AfterView
     /** XNFR-139 ***** */
     setMaxAdmins(){
         let maxAdmins =  $('#maxAdmins option:selected').val();
-        this.campaignAccess.maxAdmins = maxAdmins;
+        this.moduleAccess.maxAdmins = maxAdmins;
     }
     
     getPartnerDetails(){
@@ -2044,12 +2044,12 @@ export class EditCompanyProfileComponent implements OnInit, OnDestroy, AfterView
 
     /***XNFR-595****/
     customUiSwitchEventReceiver(event:any){
-        this.campaignAccess.paymentOverDue = event;
+        this.moduleAccess.paymentOverDue = event;
     }
    
 
     setSSOValue(event:any){
-        this.campaignAccess.ssoEnabled = event;
+        this.moduleAccess.ssoEnabled = event;
     }
 
     /** XNFR-618 **/
@@ -2081,7 +2081,7 @@ export class EditCompanyProfileComponent implements OnInit, OnDestroy, AfterView
     }
 
     setReferVendorValue(event:boolean){
-        this.campaignAccess.referVendor = event;
+        this.moduleAccess.referVendor = event;
     }
     isValidTwitterLink(twitterLink: any) {
         const  regex =  /^(https?:\/\/)?(www\.)?x\.com(\/.*)?$/;
@@ -2099,18 +2099,18 @@ export class EditCompanyProfileComponent implements OnInit, OnDestroy, AfterView
 
     /**XNFR-832***/
     unlockMdfFundingUiSwitchEventReceiver(event:any){
-        this.campaignAccess.unlockMdfFundingEnabled = event;
+        this.moduleAccess.unlockMdfFundingEnabled = event;
     }
 
     /**XNFR-878***/
     allowVendorToChangePartnerPrimaryAdminUiSwitchEventReceiver(event:any){
-        this.campaignAccess.allowVendorToChangePartnerPrimaryAdmin = event;
+        this.moduleAccess.allowVendorToChangePartnerPrimaryAdmin = event;
     }
   
     contactUploadQuotaEnabledUiSwitchEventReceiver(event: boolean) {
         this.disableContactSubscriptionLimitField = !event;
-        this.campaignAccess.contactSubscriptionLimitEnabled = event;
-        const contactSubscriptionLimit = this.campaignAccess.contactSubscriptionLimit;
+        this.moduleAccess.contactSubscriptionLimitEnabled = event;
+        const contactSubscriptionLimit = this.moduleAccess.contactSubscriptionLimit;
         if (event && (!contactSubscriptionLimit || contactSubscriptionLimit == 0)) {
             this.disableModuleAccessButton();
             this.contactSubscriptionLimitErrorMessage = this.properties.CONTACT_SUBSCRIPTION_ERROR_TOOLTIP_FOR_SUPER_ADMIN;
@@ -2121,9 +2121,9 @@ export class EditCompanyProfileComponent implements OnInit, OnDestroy, AfterView
     }
 
     contactUploadQuotaLimitChange(contactSubscriptionLimit: number) {
-        this.campaignAccess.contactSubscriptionLimit = contactSubscriptionLimit;
+        this.moduleAccess.contactSubscriptionLimit = contactSubscriptionLimit;
         const isQuotaInvalid = contactSubscriptionLimit == 0 || !contactSubscriptionLimit;
-        if (this.campaignAccess.contactSubscriptionLimitEnabled && isQuotaInvalid) {
+        if (this.moduleAccess.contactSubscriptionLimitEnabled && isQuotaInvalid) {
             this.disableModuleAccessButton();
             this.contactSubscriptionLimitErrorMessage = this.properties.CONTACT_SUBSCRIPTION_ERROR_TOOLTIP_FOR_SUPER_ADMIN;
         } else {
@@ -2142,13 +2142,13 @@ export class EditCompanyProfileComponent implements OnInit, OnDestroy, AfterView
 
     oliverActiveUiSwitchEventReceiver(event: boolean) {
         this.disableOliverAgentModuleOptions = !event;
-        this.campaignAccess.oliverActive = event;
+        this.moduleAccess.oliverActive = event;
     }
 
     /*** XNFR-1066 ***/
     onVanityUrlChange() {
-        if (!this.campaignAccess.vanityUrlDomain) {
-            this.campaignAccess.marketingModulesEnabled = false;
+        if (!this.moduleAccess.vanityUrlDomain) {
+            this.moduleAccess.marketingModulesEnabled = false;
         }
     }
 

--- a/src/app/dashboard/company-profile/models/company-profile.ts
+++ b/src/app/dashboard/company-profile/models/company-profile.ts
@@ -1,4 +1,4 @@
-import { CampaignAccess } from '../../../campaigns/models/campaign-access';
+import { ModuleAccess } from '../../../campaigns/models/module-access';
 
 export class CompanyProfile {
     id = 0;
@@ -30,7 +30,7 @@ export class CompanyProfile {
     firstName:string = "";
     lastName:string = "";
     
-    campaignAccessDto:CampaignAccess;
+    moduleAccessDto: ModuleAccess;
 
     showVendorCompanyLogo:boolean = true;
     favIconLogoPath:string;

--- a/src/app/dashboard/company-profile/services/company-profile.service.ts
+++ b/src/app/dashboard/company-profile/services/company-profile.service.ts
@@ -4,7 +4,7 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
 import { CompanyProfile } from '../models/company-profile';
 import { AuthenticationService } from '../../../core/services/authentication.service';
-import { CampaignAccess } from '../../../campaigns/models/campaign-access';
+import { ModuleAccess } from '../../../campaigns/models/module-access';
 import { CustomLoginScreen } from 'app/vanity-url/models/custom-login-screen';
 import { CompanyLoginTemplateActive } from 'app/email-template/models/company-login-template-active';
 
@@ -72,8 +72,8 @@ export class CompanyProfileService {
             .catch(this.handleError);
     }
 
-    upgradeToVendorRole(campaignAccess: CampaignAccess) {
-        return this.http.post(this.URL + "upgradeToVendor?access_token=" + this.authenticationService.access_token, campaignAccess)
+    upgradeToVendorRole(moduleAccess: ModuleAccess) {
+        return this.http.post(this.URL + "upgradeToVendor?access_token=" + this.authenticationService.access_token, moduleAccess)
             .map(this.extractData)
             .catch(this.handleError);
     }

--- a/src/app/dashboard/dashboard.service.ts
+++ b/src/app/dashboard/dashboard.service.ts
@@ -318,8 +318,8 @@ export class DashboardService {
     }
 
 
-    changeAccess(campaignAccess: any) {
-        return this.http.post(this.authenticationService.REST_URL + `module/updateAccess?access_token=${this.authenticationService.access_token}`, campaignAccess)
+    changeAccess(moduleAccess: any) {
+        return this.http.post(this.authenticationService.REST_URL + `module/updateAccess?access_token=${this.authenticationService.access_token}`, moduleAccess)
             .map(this.extractData)
             .catch(this.handleError);
     }
@@ -359,9 +359,9 @@ export class DashboardService {
             .catch(this.handleError);
     }
 
-    updatePartnerModuleAccess(campaignAccess: any){
+    updatePartnerModuleAccess(moduleAccess: any){
         const url = this.superAdminUrl + 'updatePartnerModules?access_token=' + this.authenticationService.access_token;
-        return this.http.post(url, campaignAccess)
+        return this.http.post(url, moduleAccess)
             .map(this.extractData)
             .catch(this.handleError);
     }

--- a/src/app/dashboard/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard/dashboard.component.ts
@@ -21,7 +21,7 @@ import { UserDefaultPage } from '../../core/models/user-default-page';
 import { PagerService } from '../../core/services/pager.service';
 import { XtremandLogger } from '../../error-pages/xtremand-logger.service';
 import { DashboardStatesReport } from '../models/dashboard-states-report';
-import { CampaignAccess } from 'app/campaigns/models/campaign-access';
+import { ModuleAccess } from 'app/campaigns/models/module-access';
 import { setDayOfWeek } from 'ngx-bootstrap/chronos/units/day-of-week';
 declare var Metronic, $, Layout, Demo, Index, QuickSidebar, Highcharts, Tasks: any;
 
@@ -38,7 +38,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     dashboardReport: DashboardReport = new DashboardReport();
     userDefaultPage: UserDefaultPage = new UserDefaultPage();
     socialConnections: SocialConnection[] = new Array<SocialConnection>();
-    campaignAccess:CampaignAccess = new CampaignAccess();
+    moduleAccess: ModuleAccess = new ModuleAccess();
     totalRecords: number;
     campaigns: Campaign[];
     launchedCampaignsMaster: any[];

--- a/src/app/dashboard/module-access/module-access.component.html
+++ b/src/app/dashboard/module-access/module-access.component.html
@@ -229,11 +229,11 @@
 										</a>
 									</th>
 									<td style="width: 50%;">
-										<select class="form-control" id="maxAdmins-Edit" [(ngModel)]="campaignAccess.maxAdmins" (change)="setMaxAdmins()">
-											<option value="2" [selected]="campaignAccess.maxAdmins ==2">2</option>
-											<option value="3" [selected]="campaignAccess.maxAdmins ==3">3</option>
-											<option value="4" [selected]="campaignAccess.maxAdmins ==4">4</option>
-											<option value="5" [selected]="campaignAccess.maxAdmins ==5">5</option>
+										<select class="form-control" id="maxAdmins-Edit" [(ngModel)]="moduleAccess.maxAdmins" (change)="setMaxAdmins()">
+											<option value="2" [selected]="moduleAccess.maxAdmins ==2">2</option>
+											<option value="3" [selected]="moduleAccess.maxAdmins ==3">3</option>
+											<option value="4" [selected]="moduleAccess.maxAdmins ==4">4</option>
+											<option value="5" [selected]="moduleAccess.maxAdmins ==5">5</option>
 										</select>
 									</td>	
 								</tr>
@@ -241,117 +241,117 @@
 									<tr>
 										<th scope="row">Sales Enablement (View In Browser In Create Campaign)</th>
 										<td><input class="checkBox_shadow" type="checkbox"
-												[(ngModel)]="campaignAccess.salesEnablement"
+												[(ngModel)]="moduleAccess.salesEnablement"
 												[ngModelOptions]="{standalone: true}"></td>
 									</tr>
 									<tr>
 										<th scope="row">Data Share</th>
 										<td><input class="checkBox_shadow" type="checkbox"
-												[(ngModel)]="campaignAccess.dataShare"
+												[(ngModel)]="moduleAccess.dataShare"
 												[ngModelOptions]="{standalone: true}"></td>
 									</tr>
 									<tr>
 									<th scope="row">Email Campaign</th>
 									<td><input class="checkBox_shadow" type="checkbox"
-											[(ngModel)]="campaignAccess.emailCampaign"
+											[(ngModel)]="moduleAccess.emailCampaign"
 											[ngModelOptions]="{standalone: true}"></td>
 									</tr>
 									<tr>
 										<th scope="row">Video Campaign</th>
 										<td><input class="checkBox_shadow" type="checkbox"
-												[(ngModel)]="campaignAccess.videoCampaign"
+												[(ngModel)]="moduleAccess.videoCampaign"
 												[ngModelOptions]="{standalone: true}"></td>
 									</tr>
 									<tr>
 										<th scope="row">Social Campaign</th>
 										<td><input class="checkBox_shadow" type="checkbox"
-												[(ngModel)]="campaignAccess.socialCampaign"
+												[(ngModel)]="moduleAccess.socialCampaign"
 												[ngModelOptions]="{standalone: true}"></td>
 									</tr>
 									<tr>
 										<th scope="row">Event Campaign</th>
-										<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.eventCampaign"
+										<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.eventCampaign"
 												[ngModelOptions]="{standalone: true}"></td>
 									</tr>
 									<tr>
 										<th scope="row">Survey Campaign</th>
-										<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.survey"
+										<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.survey"
 												[ngModelOptions]="{standalone: true}"></td>
 									</tr>
 									<tr>
 										<th scope="row">Form Builder</th>
-										<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.formBuilder"
+										<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.formBuilder"
 												[ngModelOptions]="{standalone: true}"></td>
 									</tr>
 									<tr>
 										<th scope="row">Page</th>
-										<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.landingPage"
+										<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.landingPage"
 												[ngModelOptions]="{standalone: true}"></td>
 									</tr>
 									<tr>
 										<th scope="row">Page Campaign</th>
-										<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.landingPageCampaign"
+										<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.landingPageCampaign"
 												[ngModelOptions]="{standalone: true}"></td>
 									</tr>
 									
 									<!---XNFR-125---->
-									<tr *ngIf="campaignAccess.shareLeads">
+									<tr *ngIf="moduleAccess.shareLeads">
 										<th scope="row">One-Click Launch</th>
 										<td>
 											<ng-template [ngTemplateOutlet]="scheduleCampaignsInfo"></ng-template>
-											<input class="checkBox_shadow" type="checkbox" id="one-click-launch-e" [(ngModel)]="campaignAccess.oneClickLaunch"
+											<input class="checkBox_shadow" type="checkbox" id="one-click-launch-e" [(ngModel)]="moduleAccess.oneClickLaunch"
 												[ngModelOptions]="{standalone: true}" (click)="findScheduledCampaignsCount()">
 										</td>
 									</tr>
 									<tr>
 										<th scope="col">Partner Template Opened Tracking Analytics</th>
 										<td><input class="checkBox_shadow" type="checkbox"
-											[(ngModel)]="campaignAccess.campaignPartnerTemplateOpenedAnalytics"
+											[(ngModel)]="moduleAccess.campaignPartnerTemplateOpenedAnalytics"
 											[ngModelOptions]="{standalone: true}"></td>
 									</tr>
 									<!--Refer Vendor-->
 									<tr>
 										<th scope="row">{{properties?.inviteAVendor}} {{properties?.inviteAVendor}} (Option Applicable For Vanity Url)</th>
 										<td class="pt0">
-											<app-custom-ui-switch [customSwitch]="campaignAccess.referVendor" (customUiSwitchEventEmitter)="setReferVendorValue($event)"></app-custom-ui-switch>
+											<app-custom-ui-switch [customSwitch]="moduleAccess.referVendor" (customUiSwitchEventEmitter)="setReferVendorValue($event)"></app-custom-ui-switch>
 										</td>
 									</tr>
 								</ng-container>
 								<tr>
 									<th scope="row">SSO Enabled</th>
 									<td class="pt0">
-										<app-custom-ui-switch [customSwitch]="campaignAccess.ssoEnabled" (customUiSwitchEventEmitter)="setSSOValue($event)"></app-custom-ui-switch>
+										<app-custom-ui-switch [customSwitch]="moduleAccess.ssoEnabled" (customUiSwitchEventEmitter)="setSSOValue($event)"></app-custom-ui-switch>
 									</td>
 								</tr>
 								<tr>
 									<th scope="row">Share Leads</th>
 									<td>
 									<ng-template *ngIf="showOneClickLaunchErrorMessage" [ngTemplateOutlet]="scheduleCampaignsInfo"></ng-template>
-									<input class="checkBox_shadow" type="checkbox" id="share-leads-e" [(ngModel)]="campaignAccess.shareLeads"
+									<input class="checkBox_shadow" type="checkbox" id="share-leads-e" [(ngModel)]="moduleAccess.shareLeads"
 										[ngModelOptions]="{standalone: true}" (click)="updateOneClickLaunchOption()">
 									</td>
 								</tr>
 								<!--Leads (Opportunities)-->
 								<tr>
 									<th scope="row">Leads (Opportunities)</th>
-									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.leads"
+									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.leads"
 											[ngModelOptions]="{standalone: true}"></td>
 								</tr>
 								<!--Login As Team Member-->
 								<tr>
 									<th scope="row">Login As Team Member</th>
-									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.loginAsTeamMember"
+									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.loginAsTeamMember"
 											[ngModelOptions]="{standalone: true}"></td>
 								</tr>
 								<tr>
 									<th scope="row">Vanity URL</th>
-									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.vanityUrlDomain"
+									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.vanityUrlDomain"
 											[ngModelOptions]="{standalone: true}" (change)="onVanityUrlChange()"></td>
 								</tr>
 								<tr *ngIf="companyAndUserDetails?.roleName === 'ROLE_VENDOR' || companyAndUserDetails?.roleName === 'ROLE_ORG_ADMIN'">
 									<th scope="row">Enable Marketing Modules</th>
-									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.marketingModulesEnabled"
-											[ngModelOptions]="{standalone: true}" [disabled]="!campaignAccess.vanityUrlDomain"></td>
+									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.marketingModulesEnabled"
+											[ngModelOptions]="{standalone: true}" [disabled]="!moduleAccess.vanityUrlDomain"></td>
 								</tr>
 								<tr>
 									<th scope="row">MDF</th>
@@ -364,143 +364,143 @@
 											<i class="fa fa-close" aria-hidden="true"></i> &nbsp; <strong>{{companyAndUserDetails?.message}}</strong>
 										</p>
 
-										<input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.mdf"
+										<input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.mdf"
 											[ngModelOptions]="{standalone: true}">
 									</td>
 								</tr>
 								<tr> 
 									<th scope="row">Social Feeds</th>
-									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.rssFeeds"
+									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.rssFeeds"
 											[ngModelOptions]="{standalone: true}"></td>
 								</tr>
 								<tr>
 									<th scope="row">Social Share</th>
-									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.socialShareOptionEnabled"
+									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.socialShareOptionEnabled"
 											[ngModelOptions]="{standalone: true}"></td>
 								</tr>
 								<tr>
 									<th scope="row">Dashboard Type</th>
 									<td>
 										<select  class="form-control" id="dashboardType" (change)="selectDashboardType()">
-											<option value="DASHBOARD" [selected]="campaignAccess?.dashboardTypeInString=='DASHBOARD'">Dashboard</option>
-											<option value="ADVANCED_DASHBOARD" [selected]="campaignAccess?.dashboardTypeInString=='ADVANCED_DASHBOARD'">Advanced Dashboard</option>
-											<option value="DETAILED_DASHBOARD" [selected]="campaignAccess?.dashboardTypeInString=='DETAILED_DASHBOARD'">Detailed Dashboard ( Dashboard + Detailed Dashboard)</option>
+											<option value="DASHBOARD" [selected]="moduleAccess?.dashboardTypeInString=='DASHBOARD'">Dashboard</option>
+											<option value="ADVANCED_DASHBOARD" [selected]="moduleAccess?.dashboardTypeInString=='ADVANCED_DASHBOARD'">Advanced Dashboard</option>
+											<option value="DETAILED_DASHBOARD" [selected]="moduleAccess?.dashboardTypeInString=='DETAILED_DASHBOARD'">Detailed Dashboard ( Dashboard + Detailed Dashboard)</option>
 										</select>
 									</td>
 								</tr>
 								<tr>
 									<th scope="row">DAM</th>
 									<td>
-									<input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.dam" id="damCheckBox"
+									<input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.dam" id="damCheckBox"
 											[ngModelOptions]="{standalone: true}" (click)="updateLmsAndPlaybooks()"></td>
 								</tr>
-								<ng-container *ngIf="campaignAccess?.dam">
+								<ng-container *ngIf="moduleAccess?.dam">
 								<tr>
 									<th scope="row">LMS</th>
-									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.lms"
+									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.lms"
 											[ngModelOptions]="{standalone: true}"></td>
 								</tr>
 								<tr>
 									<th scope="row">PlayBooks</th>
-									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.playbooks"
+									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.playbooks"
 											[ngModelOptions]="{standalone: true}"></td>
 								</tr>
 								</ng-container>
 								<tr>
 									<th scope="row">Exclude Users/Domains</th>
-									<td><input type="checkbox" [(ngModel)]="campaignAccess.excludeUsersOrDomains"
+									<td><input type="checkbox" [(ngModel)]="moduleAccess.excludeUsersOrDomains"
 											[ngModelOptions]="{standalone: true}"></td>
 								</tr>
 								<tr>
 									<th scope="row">Chat Support</th>
-									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.chatSupport"
+									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.chatSupport"
 											[ngModelOptions]="{standalone: true}"></td>
 								</tr>
 								<!--XNFR-134-->
 								<tr>
 									<th scope="row">Custom Skin Settings</th>
-									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.customSkinSettings"
+									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.customSkinSettings"
 											[ngModelOptions]="{standalone: true}"></td>
 								</tr>
 								<!-- XNFR-224 -->
 								<tr *ngIf="!marketing">
 									<th scope="row">Login As Partner</th>
-									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.loginAsPartner"
+									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.loginAsPartner"
 											[ngModelOptions]="{standalone: true}"></td>
 								</tr>
 								<!-- XNFR-256 -->
 								<tr>
 									<th scope="row">Microsoft SSO</th>
-									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.microsoftSSO"
+									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.microsoftSSO"
 											[ngModelOptions]="{standalone: true}"></td>
 								</tr>
 						
 								<!-- XNFR-255 -->
 								<tr *ngIf="!marketing">
 									<th scope="row">Share White Labeled Content</th>
-									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.shareWhiteLabeledContent"
+									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.shareWhiteLabeledContent"
 											[ngModelOptions]="{standalone: true}"></td>
 								</tr>
 								<!--XNFR-381-->
 								<tr *ngIf="!marketing">
 									<th scope="row">Create Workflow (Partner Journey)</th>
-									<td><input type="checkbox" [(ngModel)]="campaignAccess.createWorkflow"
+									<td><input type="checkbox" [(ngModel)]="moduleAccess.createWorkflow"
 											[ngModelOptions]="{standalone: true}"></td>
 								</tr>
 								<!--XNFR-522-->
 								<tr>
 									<th scope="row">Vendor Showcase</th>
-									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.vendorJourney"
+									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.vendorJourney"
 											[ngModelOptions]="{standalone: true}"></td>
 								</tr>
 								<!--XNFR-595-->
 								<tr>
 									<th scope="row">Payment Overdue</th>
 									<td class="pt0">
-										<app-custom-ui-switch [customSwitch]="campaignAccess.paymentOverDue" (customUiSwitchEventEmitter)="customUiSwitchEventReceiver($event)"></app-custom-ui-switch>
+										<app-custom-ui-switch [customSwitch]="moduleAccess.paymentOverDue" (customUiSwitchEventEmitter)="customUiSwitchEventReceiver($event)"></app-custom-ui-switch>
 									</td>
 								</tr>
 								<!--XNFR-669-->
 								<tr>
 									<th scope="row">Welcome Pages</th>
-									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.welcomePages"
+									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.welcomePages"
 											[ngModelOptions]="{standalone: true}"></td>
 								</tr>
 								<tr>
 									<th scope="row">Vendor Landscape</th>
-									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.vendorMarketplace"
+									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.vendorMarketplace"
 											[ngModelOptions]="{standalone: true}"></td>
 								</tr>
 								<!--XNFR-820-->
 								<tr>
 									<th scope="row">Approval Hub</th>
-									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.approvalHub"
+									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.approvalHub"
 											[ngModelOptions]="{standalone: true}"></td>
 								</tr>
 								<!--XNFR-979-->
 								<tr>
 									<th scope="row">Insights</th>
-									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.insights"
+									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.insights"
 											[ngModelOptions]="{standalone: true}"></td>
 								</tr>
 								<!--XNFR-1062-->
 								<tr>
 									<th scope="row">Mail Integration</th>
-									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.mailsEnabled"
+									<td><input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.mailsEnabled"
 											[ngModelOptions]="{standalone: true}"></td>
 								</tr>
 								<!--XNFR-832-->
 								<tr *ngIf="marketing || orgAdmin">
 									<th scope="row">Unlock MDF Funding</th>
 									<td class="pt0">
-										<app-custom-ui-switch [customSwitch]="campaignAccess.unlockMdfFundingEnabled" (customUiSwitchEventEmitter)="unlockMdfFundingUiSwitchEventReceiver($event)"></app-custom-ui-switch>
+										<app-custom-ui-switch [customSwitch]="moduleAccess.unlockMdfFundingEnabled" (customUiSwitchEventEmitter)="unlockMdfFundingUiSwitchEventReceiver($event)"></app-custom-ui-switch>
 									</td>
 								</tr>
 								<!--XNFR-878-->
 								<tr *ngIf="!marketing">
 									<th scope="row">Allow Vendor to Change Partner Primary Admin</th>
 									<td class="pt0">
-										<app-custom-ui-switch [customSwitch]="campaignAccess.allowVendorToChangePartnerPrimaryAdmin" (customUiSwitchEventEmitter)="allowVendorToChangePartnerPrimaryAdminUiSwitchEventReceiver($event)"></app-custom-ui-switch>
+										<app-custom-ui-switch [customSwitch]="moduleAccess.allowVendorToChangePartnerPrimaryAdmin" (customUiSwitchEventEmitter)="allowVendorToChangePartnerPrimaryAdminUiSwitchEventReceiver($event)"></app-custom-ui-switch>
 									</td>
 								</tr>
 								<tr>
@@ -508,11 +508,11 @@
 										<img src="assets/images/oliverAiLogo.svg" alt="Oliver Icon" width="22px" height="22px">
 									</th>
 
-									<td *ngIf="campaignAccess.oliverFilesProcessing"><img style="height: 40px; padding-left: 0px;"
+									<td *ngIf="moduleAccess.oliverFilesProcessing"><img style="height: 40px; padding-left: 0px;"
 											src="../../../assets/images/Spinner.gif" alt="">Processing Files to Oliver</td>
 
-									<td *ngIf="!campaignAccess.oliverFilesProcessing">
-										<app-custom-ui-switch [customSwitch]="campaignAccess.oliverActive"
+									<td *ngIf="!moduleAccess.oliverFilesProcessing">
+										<app-custom-ui-switch [customSwitch]="moduleAccess.oliverActive"
 											(customUiSwitchEventEmitter)="oliverActiveUiSwitchEventReceiver($event)"></app-custom-ui-switch>
 										<div style="margin-left: 20px; margin-top: 10px;">
 											<div>
@@ -534,14 +534,14 @@
 											<div>
 												<strong>
 													<input class="checkBox_shadow" type="checkbox" [disabled]="disableOliverAgentModuleOptions"
-														[(ngModel)]="campaignAccess.oliverInsightsEnabled" [ngModelOptions]="{standalone: true}">
+														[(ngModel)]="moduleAccess.oliverInsightsEnabled" [ngModelOptions]="{standalone: true}">
 													<span class="ml10">Enable Oliver Insights</span>
 												</strong>
 											</div>
 									
 											<div>
 												<strong>
-													<input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.brainstormWithOliverEnabled"
+													<input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.brainstormWithOliverEnabled"
 														[ngModelOptions]="{standalone: true}" [disabled]="disableOliverAgentModuleOptions">
 													<span class="ml10">Enable Brainstorm With Oliver</span>
 												</strong>
@@ -549,21 +549,21 @@
 									
 											<div>
 												<strong>
-													<input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.oliverSparkWriterEnabled"
+													<input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.oliverSparkWriterEnabled"
 														[ngModelOptions]="{standalone: true}" [disabled]="disableOliverAgentModuleOptions">
 													<span class="ml10">Enable Oliver Spark Writer</span>
 												</strong>
 											</div>
 											<div>
 												<strong>
-													<input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.oliverParaphraserEnabled"
+													<input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.oliverParaphraserEnabled"
 														[ngModelOptions]="{standalone: true}" [disabled]="disableOliverAgentModuleOptions">
 													<span class="ml10">Enable Oliver Paraphraser</span>
 												</strong>
 											</div>
 											<div>
 												<strong>
-													<input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.oliverContactAgentEnabled"
+													<input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.oliverContactAgentEnabled"
 														[ngModelOptions]="{standalone: true}" [disabled]="disableOliverAgentModuleOptions">
 													<span class="ml10">Enable Oliver Contact Agent</span>
 												</strong>
@@ -571,14 +571,14 @@
 
 											<div>
 												<strong>
-													<input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.oliverPartnerAgentEnabled"
+													<input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.oliverPartnerAgentEnabled"
 														[ngModelOptions]="{standalone: true}" [disabled]="disableOliverAgentModuleOptions">
 													<span class="ml10">Enable Oliver Partner Agent</span>
 												</strong>
 											</div>
 											<div>
 												<strong>
-													<input class="checkBox_shadow" type="checkbox" [(ngModel)]="campaignAccess.oliverCampaignAgentEnabled"
+													<input class="checkBox_shadow" type="checkbox" [(ngModel)]="moduleAccess.oliverCampaignAgentEnabled"
 														[ngModelOptions]="{standalone: true}" [disabled]="disableOliverAgentModuleOptions">
 													<span class="ml10">Enable Oliver Campaign Agent</span>
 												</strong>
@@ -591,28 +591,28 @@
 								<tr *ngIf="!prm">
 									<th scope="row"> Contact Limit </th>
 									<td class="pt0">
-										<app-custom-ui-switch [customSwitch]="campaignAccess.contactSubscriptionLimitEnabled"
+										<app-custom-ui-switch [customSwitch]="moduleAccess.contactSubscriptionLimitEnabled"
 											(customUiSwitchEventEmitter)="contactUploadQuotaEnabledUiSwitchEventReceiver($event)"></app-custom-ui-switch>
 										<span style="padding-left: 5px;">
 											<span class="required"><Strong>*</Strong></span>
 											<strong>Contact Limit: </strong>
 											<input [disabled]="disableContactSubscriptionLimitField"
 												style="margin: 5px 15px;width: 25%;display: inline-flex" type="number"
-												[(ngModel)]="campaignAccess.contactSubscriptionLimit" [ngModelOptions]="{standalone: true}"
+												[(ngModel)]="moduleAccess.contactSubscriptionLimit" [ngModelOptions]="{standalone: true}"
 												class="form-control" name="contactSubscriptionLimit" placeholder="Enter Limit Here" min="1"
 												oninput="validity.valid||(value='');"
-												(input)="contactUploadQuotaLimitChange(campaignAccess.contactSubscriptionLimit)">
+												(input)="contactUploadQuotaLimitChange(moduleAccess.contactSubscriptionLimit)">
 										</span>
 										<span>
 											<strong>
 												Limit Exceeded By:
 												<span *ngIf="!contactSubscriptionLoader?.isLoading" [ngStyle]="{
-													'color': (totalContactSubscriptionUsed > campaignAccess.contactSubscriptionLimit
-														? totalContactSubscriptionUsed - campaignAccess.contactSubscriptionLimit
+													'color': (totalContactSubscriptionUsed > moduleAccess.contactSubscriptionLimit
+														? totalContactSubscriptionUsed - moduleAccess.contactSubscriptionLimit
 														: 0) > 0 ? 'red' : 'inherit'
 														}">
-													{{ totalContactSubscriptionUsed > campaignAccess.contactSubscriptionLimit
-													? totalContactSubscriptionUsed - campaignAccess.contactSubscriptionLimit
+													{{ totalContactSubscriptionUsed > moduleAccess.contactSubscriptionLimit
+													? totalContactSubscriptionUsed - moduleAccess.contactSubscriptionLimit
 													: 0 }}
 												</span>
 												<img *ngIf="contactSubscriptionLoader?.isLoading" style="height: 40px; padding-left: 0px;"

--- a/src/app/dashboard/module-access/module-access.component.ts
+++ b/src/app/dashboard/module-access/module-access.component.ts
@@ -4,7 +4,7 @@ import { AuthenticationService } from 'app/core/services/authentication.service'
 import { DashboardService } from 'app/dashboard/dashboard.service';
 import { ActivatedRoute } from '@angular/router';
 import { CustomResponse } from 'app/common/models/custom-response';
-import { CampaignAccess } from 'app/campaigns/models/campaign-access';
+import { ModuleAccess } from 'app/campaigns/models/module-access';
 import { ReferenceService } from 'app/core/services/reference.service';
 import { HttpRequestLoader } from 'app/core/models/http-request-loader';
 import { MdfService } from 'app/mdf/services/mdf.service';
@@ -30,7 +30,7 @@ export class ModuleAccessComponent implements OnInit {
   userAlias: any;
   companyProfilename: any
   customResponse: CustomResponse = new CustomResponse();
-  campaignAccess = new CampaignAccess();
+  moduleAccess = new ModuleAccess();
   moduleAccessList: any = [];
   companyAndUserDetails: any;
   companyLoader = true;
@@ -352,9 +352,9 @@ export class ModuleAccessComponent implements OnInit {
   getModuleAccessByCompanyId() {
     if (this.companyId) {
       this.dashboardService.getAccess(this.companyId).subscribe(result => {
-        this.campaignAccess = result;
-        this.oliverActive = this.campaignAccess.oliverActive;
-        if (this.oliverActive && !this.campaignAccess.oliverFilesProcessing) {
+        this.moduleAccess = result;
+        this.oliverActive = this.moduleAccess.oliverActive;
+        if (this.oliverActive && !this.moduleAccess.oliverFilesProcessing) {
           this.fetchOliverActiveIntegrationType();
         }
         this.moduleLoader = false;
@@ -362,8 +362,8 @@ export class ModuleAccessComponent implements OnInit {
         this.moduleLoader = false;
         this.customResponse = new CustomResponse('ERROR', 'Something went wrong.', true);
       }, () => {
-        this.disableContactSubscriptionLimitField = !this.campaignAccess.contactSubscriptionLimitEnabled;
-        this.setOliverAgentFlagValues(this.campaignAccess);
+        this.disableContactSubscriptionLimitField = !this.moduleAccess.contactSubscriptionLimitEnabled;
+        this.setOliverAgentFlagValues(this.moduleAccess);
       });
     }
   }
@@ -373,13 +373,13 @@ export class ModuleAccessComponent implements OnInit {
   updateModuleAccess() {
     this.customResponse = new CustomResponse();
     this.ngxLoading = true;
-    this.campaignAccess.companyId = this.companyId;
-    this.campaignAccess.userId = this.companyAndUserDetails.id;
-    if (this.campaignAccess.oliverActive && ((this.campaignAccess.oliverActive != this.oliverActive) || (this.campaignAccess.oliverIntegrationType != this.oliverIntegrationType))) {
-      this.campaignAccess.oliverAccessStatus = true;
-      this.campaignAccess.oliverIntegrationType = this.oliverIntegrationType;
+    this.moduleAccess.companyId = this.companyId;
+    this.moduleAccess.userId = this.companyAndUserDetails.id;
+    if (this.moduleAccess.oliverActive && ((this.moduleAccess.oliverActive != this.oliverActive) || (this.moduleAccess.oliverIntegrationType != this.oliverIntegrationType))) {
+      this.moduleAccess.oliverAccessStatus = true;
+      this.moduleAccess.oliverIntegrationType = this.oliverIntegrationType;
     }
-    this.dashboardService.changeAccess(this.campaignAccess).subscribe(result => {
+    this.dashboardService.changeAccess(this.moduleAccess).subscribe(result => {
       this.statusCode = result.statusCode;
       this.customResponse = new CustomResponse('ERROR', result.message, true);
       this.ngxLoading = false;
@@ -389,7 +389,7 @@ export class ModuleAccessComponent implements OnInit {
     },
       () => {
         if (this.statusCode == 200) {
-          if (this.campaignAccess.mdf && !this.companyAndUserDetails.defaultMdfFormAvaible) {
+          if (this.moduleAccess.mdf && !this.companyAndUserDetails.defaultMdfFormAvaible) {
             this.ngxLoading = true;
             this.addDefaultMdfForm();
           } else {
@@ -441,25 +441,25 @@ export class ModuleAccessComponent implements OnInit {
     this.prm = this.roleId==20;
     this.marketing = this.roleId==18;
     if(this.prm){
-      this.campaignAccess.emailCampaign = false;
-      this.campaignAccess.videoCampaign = false;
-      this.campaignAccess.videoCampaign = false;
-      this.campaignAccess.socialCampaign = false;
-      this.campaignAccess.eventCampaign = false;
-      this.campaignAccess.survey = false;
-      this.campaignAccess.formBuilder = true;
-      this.campaignAccess.landingPage = false;
-      this.campaignAccess.landingPageCampaign = false;
-      this.campaignAccess.allBoundSource = false;
-      this.campaignAccess.campaignPartnerTemplateOpenedAnalytics = false;
-      this.campaignAccess.salesEnablement = false;
-      this.campaignAccess.dataShare = false;
-      this.campaignAccess.referVendor = false;
-      this.campaignAccess.ssoEnabled = false;
+      this.moduleAccess.emailCampaign = false;
+      this.moduleAccess.videoCampaign = false;
+      this.moduleAccess.videoCampaign = false;
+      this.moduleAccess.socialCampaign = false;
+      this.moduleAccess.eventCampaign = false;
+      this.moduleAccess.survey = false;
+      this.moduleAccess.formBuilder = true;
+      this.moduleAccess.landingPage = false;
+      this.moduleAccess.landingPageCampaign = false;
+      this.moduleAccess.allBoundSource = false;
+      this.moduleAccess.campaignPartnerTemplateOpenedAnalytics = false;
+      this.moduleAccess.salesEnablement = false;
+      this.moduleAccess.dataShare = false;
+      this.moduleAccess.referVendor = false;
+      this.moduleAccess.ssoEnabled = false;
     }else if(this.marketing){
-      this.campaignAccess.loginAsPartner = false;
-      this.campaignAccess.shareWhiteLabeledContent = false;
-      this.campaignAccess.createWorkflow = false;
+      this.moduleAccess.loginAsPartner = false;
+      this.moduleAccess.shareWhiteLabeledContent = false;
+      this.moduleAccess.createWorkflow = false;
     }
     else{
      this.getModuleAccessByCompanyId();
@@ -469,19 +469,19 @@ export class ModuleAccessComponent implements OnInit {
   selectDashboardType(){
     let selectedDashboard = $('#dashboardType option:selected').val();
     if(selectedDashboard==DashboardType[DashboardType.DASHBOARD]){
-      this.campaignAccess.dashboardType = DashboardType.DASHBOARD;
+      this.moduleAccess.dashboardType = DashboardType.DASHBOARD;
     }else if(selectedDashboard==DashboardType[DashboardType.ADVANCED_DASHBOARD]){
-      this.campaignAccess.dashboardType = DashboardType.ADVANCED_DASHBOARD;
+      this.moduleAccess.dashboardType = DashboardType.ADVANCED_DASHBOARD;
     }else if(selectedDashboard==DashboardType[DashboardType.DETAILED_DASHBOARD]){
-      this.campaignAccess.dashboardType = DashboardType.DETAILED_DASHBOARD;
+      this.moduleAccess.dashboardType = DashboardType.DETAILED_DASHBOARD;
     }
   }
 
   updateLmsAndPlaybooks(){
     let isDamChecked = $('#damCheckBox').is(':checked');
     if(!isDamChecked){
-      this.campaignAccess.lms = false;
-      this.campaignAccess.playbooks = false;
+      this.moduleAccess.lms = false;
+      this.moduleAccess.playbooks = false;
     }
   }
 
@@ -490,7 +490,7 @@ export class ModuleAccessComponent implements OnInit {
     let shareLeadsChecked = $('#share-leads-e').is(':checked');
     if(!shareLeadsChecked){
       this.showOneClickLaunchErrorMessage = true;
-      this.campaignAccess.oneClickLaunch = false;
+      this.moduleAccess.oneClickLaunch = false;
       this.findScheduledCampaignsCount();
     }
   }
@@ -516,7 +516,7 @@ export class ModuleAccessComponent implements OnInit {
   /** XNFR-139 ***** */
   setMaxAdmins(){
     let maxAdmins =  $('#maxAdmins-Edit option:selected').val();
-    this.campaignAccess.maxAdmins = maxAdmins;
+    this.moduleAccess.maxAdmins = maxAdmins;
   }
 
 findMaximumAdminsLimitDetails(){
@@ -602,40 +602,40 @@ startCompanyProfileLoader(){
 
  /***XNFR-595****/
  customUiSwitchEventReceiver(event:any){
-  this.campaignAccess.paymentOverDue = event;
+  this.moduleAccess.paymentOverDue = event;
 }
 
 setSSOValue(event:boolean){
-  this.campaignAccess.ssoEnabled = event;
+  this.moduleAccess.ssoEnabled = event;
 }
 
 setReferVendorValue(event:boolean){
-  this.campaignAccess.referVendor = event;
+  this.moduleAccess.referVendor = event;
 }
 
 /**XNFR-832***/
 unlockMdfFundingUiSwitchEventReceiver(event:any){
-  this.campaignAccess.unlockMdfFundingEnabled = event;
+  this.moduleAccess.unlockMdfFundingEnabled = event;
 }
 
 /**XNFR-878***/
 allowVendorToChangePartnerPrimaryAdminUiSwitchEventReceiver(event:any){
-  this.campaignAccess.allowVendorToChangePartnerPrimaryAdmin = event;
+  this.moduleAccess.allowVendorToChangePartnerPrimaryAdmin = event;
 }
 
   /** XNFR-952  start **/
  contactUploadQuotaEnabledUiSwitchEventReceiver(event: boolean) {
     this.disableContactSubscriptionLimitField = !event;
-    this.campaignAccess.contactSubscriptionLimitEnabled = event;
-    const contactSubscriptionLimit = this.campaignAccess.contactSubscriptionLimit;
+    this.moduleAccess.contactSubscriptionLimitEnabled = event;
+    const contactSubscriptionLimit = this.moduleAccess.contactSubscriptionLimit;
     this.disableUpdateModulesButton = event && (!contactSubscriptionLimit || contactSubscriptionLimit == 0);
     this.contactSubscriptionLimitErrorMessage = this.disableUpdateModulesButton ? this.properties.CONTACT_SUBSCRIPTION_ERROR_TOOLTIP_FOR_SUPER_ADMIN  : "";
   }
   
   contactUploadQuotaLimitChange(contactSubscriptionLimit: number): void {
-    this.campaignAccess.contactSubscriptionLimit = contactSubscriptionLimit;
+    this.moduleAccess.contactSubscriptionLimit = contactSubscriptionLimit;
     const isQuotaInvalid = contactSubscriptionLimit == 0 || !contactSubscriptionLimit;
-    this.disableUpdateModulesButton = this.campaignAccess.contactSubscriptionLimitEnabled && isQuotaInvalid;
+    this.disableUpdateModulesButton = this.moduleAccess.contactSubscriptionLimitEnabled && isQuotaInvalid;
     this.contactSubscriptionLimitErrorMessage = this.disableUpdateModulesButton ? this.properties.CONTACT_SUBSCRIPTION_ERROR_TOOLTIP_FOR_SUPER_ADMIN  : "";
   }
 
@@ -652,35 +652,35 @@ allowVendorToChangePartnerPrimaryAdminUiSwitchEventReceiver(event:any){
     }
   }
 
-  setOliverAgentFlagValues(campaignAccess: CampaignAccess) {
-    this.oliverInsightsEnabledFlag = campaignAccess.oliverInsightsEnabled;
-    this.brainstormWithOliverEnabledFlag = campaignAccess.brainstormWithOliverEnabled;
-    this.oliverSparkWriterEnabledFlag = campaignAccess.oliverSparkWriterEnabled;
-    this.oliverParaphraserEnabledFlag = campaignAccess.oliverParaphraserEnabled;
-    this.oliverContactAgentEnabledFlag = campaignAccess.oliverContactAgentEnabled;
-    this.oliverPartnerAgentEnabledFlag = campaignAccess.oliverPartnerAgentEnabled;
-    this.oliverCampaignAgentEnabledFlag = campaignAccess.oliverCampaignAgentEnabled;
+  setOliverAgentFlagValues(moduleAccess: ModuleAccess) {
+    this.oliverInsightsEnabledFlag = moduleAccess.oliverInsightsEnabled;
+    this.brainstormWithOliverEnabledFlag = moduleAccess.brainstormWithOliverEnabled;
+    this.oliverSparkWriterEnabledFlag = moduleAccess.oliverSparkWriterEnabled;
+    this.oliverParaphraserEnabledFlag = moduleAccess.oliverParaphraserEnabled;
+    this.oliverContactAgentEnabledFlag = moduleAccess.oliverContactAgentEnabled;
+    this.oliverPartnerAgentEnabledFlag = moduleAccess.oliverPartnerAgentEnabled;
+    this.oliverCampaignAgentEnabledFlag = moduleAccess.oliverCampaignAgentEnabled;
   }
   /** XNFR-952 end **/
 
   oliverActiveUiSwitchEventReceiver(event: boolean) {
     this.disableOliverAgentModuleOptions = !event;
-    this.campaignAccess.oliverActive = event;
+    this.moduleAccess.oliverActive = event;
     this.disableUpdateModulesButton = event && !this.oliverIntegrationType;
     if (!event) {
-      this.campaignAccess.oliverInsightsEnabled = this.oliverInsightsEnabledFlag;
-      this.campaignAccess.brainstormWithOliverEnabled = this.brainstormWithOliverEnabledFlag;
-      this.campaignAccess.oliverSparkWriterEnabled = this.oliverSparkWriterEnabledFlag;
-      this.campaignAccess.oliverParaphraserEnabled = this.oliverParaphraserEnabledFlag;
-      this.campaignAccess.oliverContactAgentEnabled = this.oliverContactAgentEnabledFlag;
-      this.campaignAccess.oliverCampaignAgentEnabled = this.oliverCampaignAgentEnabledFlag;
+      this.moduleAccess.oliverInsightsEnabled = this.oliverInsightsEnabledFlag;
+      this.moduleAccess.brainstormWithOliverEnabled = this.brainstormWithOliverEnabledFlag;
+      this.moduleAccess.oliverSparkWriterEnabled = this.oliverSparkWriterEnabledFlag;
+      this.moduleAccess.oliverParaphraserEnabled = this.oliverParaphraserEnabledFlag;
+      this.moduleAccess.oliverContactAgentEnabled = this.oliverContactAgentEnabledFlag;
+      this.moduleAccess.oliverCampaignAgentEnabled = this.oliverCampaignAgentEnabledFlag;
     }
   }
 
   onIntegrationTypeChange(selected: any) {
     this.oliverIntegrationType = selected;
     this.disableUpdateModulesButton = false;
-    // this.campaignAccess.oliverAccessStatus = true;
+    // this.moduleAccess.oliverAccessStatus = true;
   }
 
   fetchOliverActiveIntegrationType() {
@@ -689,8 +689,8 @@ allowVendorToChangePartnerPrimaryAdminUiSwitchEventReceiver(event:any){
 
   /*** XNFR-1066 ***/
   onVanityUrlChange() {
-    if (!this.campaignAccess.vanityUrlDomain) {
-      this.campaignAccess.marketingModulesEnabled = false;
+    if (!this.moduleAccess.vanityUrlDomain) {
+      this.moduleAccess.marketingModulesEnabled = false;
     }
   }
 

--- a/src/app/dashboard/notify-partners/notify-partners.component.ts
+++ b/src/app/dashboard/notify-partners/notify-partners.component.ts
@@ -25,9 +25,9 @@ export class NotifyPartnersComponent implements OnInit {
    this.customResponse = new CustomResponse();
     const user = JSON.parse(localStorage.getItem('currentUser'));
     let hasCompany = user.hasCompany;
-    let campaignAccessDto = user.campaignAccessDto;
-    if(hasCompany && campaignAccessDto!=undefined){
-      this.companyId= user.campaignAccessDto.companyId;
+    let moduleAccessDto = user.moduleAccessDto || user.campaignAccessDto;
+    if(hasCompany && moduleAccessDto!=undefined){
+      this.companyId= moduleAccessDto.companyId;
     }
     this.findNotifyPartnersOption();
   }

--- a/src/app/dashboard/oauth-sso-configuration/oauth-sso-configuration.component.ts
+++ b/src/app/dashboard/oauth-sso-configuration/oauth-sso-configuration.component.ts
@@ -85,7 +85,7 @@ export class OauthSsoConfigurationComponent implements OnInit {
 
   saveOrUpdateOauthSsoConfiguration() {
     let self = this;
-    self.oauthSso.companyId = self.authenticationService.user.campaignAccessDto.companyId;
+    self.oauthSso.companyId = self.authenticationService.user.moduleAccessDto.companyId;
     self.oauthSso.createdBy = self.loggedInUserId;
     self.ngxLoading = true;
     self.oauthSsoService.saveOrUpdateOauthSsoConfiguration(self.oauthSso).subscribe(data => {

--- a/src/app/dashboard/saml-sso-login/saml-sso-login.component.ts
+++ b/src/app/dashboard/saml-sso-login/saml-sso-login.component.ts
@@ -57,7 +57,7 @@ export class SamlSsoLoginComponent implements OnInit {
     if (self.samlSecurityObj.id === undefined || self.samlSecurityObj.id === null) {
       let samlObj = {
         emailId: self.emailId,
-        companyId: self.authenticationService.user.campaignAccessDto.companyId,
+        companyId: self.authenticationService.user.moduleAccessDto.companyId,
         createdByUserId: self.loggedInUserId
       }
       self.samlSecurityService.saveSaml2Security(samlObj).subscribe(response => {

--- a/src/app/dashboard/samlsecurity/samlsecurity.component.ts
+++ b/src/app/dashboard/samlsecurity/samlsecurity.component.ts
@@ -35,7 +35,7 @@ export class SamlsecurityComponent implements OnInit {
       if (this.samlSecurityObj.id === undefined || this.samlSecurityObj.id === null) {
         let samlObj = {
           emailId: this.emailId,
-          companyId: this.authenticationService.user.campaignAccessDto.companyId
+          companyId: this.authenticationService.user.moduleAccessDto.companyId
         }
         this.samlSecurityService.saveSamlSecurity(samlObj).subscribe(response => {
           this.samlSecurityObj = response;

--- a/src/app/dashboard/spf/spf.component.ts
+++ b/src/app/dashboard/spf/spf.component.ts
@@ -52,9 +52,9 @@ refreshText :string;
   ngOnInit() {
      const user = JSON.parse(localStorage.getItem('currentUser'));
       let hasCompany = user.hasCompany;
-      let campaignAccessDto = user.campaignAccessDto;
-      if(hasCompany && campaignAccessDto!=undefined){
-        this.companyId= user.campaignAccessDto.companyId;
+      let moduleAccessDto = user.moduleAccessDto || user.campaignAccessDto;
+      if(hasCompany && moduleAccessDto!=undefined){
+        this.companyId= moduleAccessDto.companyId;
       }
       this.isSpfConfigured();
       this.isGodaddyConfigured();

--- a/src/app/dashboard/vendor-report/vendor-report.component.ts
+++ b/src/app/dashboard/vendor-report/vendor-report.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
-import { CampaignAccess } from 'app/campaigns/models/campaign-access';
+import { ModuleAccess } from 'app/campaigns/models/module-access';
 import { CustomResponse } from 'app/common/models/custom-response';
 import { Properties } from 'app/common/models/properties';
 import { HttpRequestLoader } from 'app/core/models/http-request-loader';
@@ -15,7 +15,7 @@ declare var $: any, swal: any;
     selector: 'app-vendor-report',
     templateUrl: './vendor-report.component.html',
     styleUrls: ['./vendor-report.component.css'],
-    providers: [Pagination, HttpRequestLoader, Properties, CampaignAccess]
+    providers: [Pagination, HttpRequestLoader, Properties, ModuleAccess]
 })
 export class VendorReportComponent implements OnInit {
 

--- a/src/app/deals/select-contact/select-contact.component.ts
+++ b/src/app/deals/select-contact/select-contact.component.ts
@@ -60,8 +60,8 @@ export class SelectContactComponent implements OnInit {
       this.vanityLoginDto.vanityUrlFilter = true;
     }
     const currentUser = localStorage.getItem('currentUser');
-    let campaginAccessDto = JSON.parse(currentUser)['campaignAccessDto'];
-    this.companyId = campaginAccessDto.companyId;
+    let moduleAccessDto = JSON.parse(currentUser)['moduleAccessDto'] || JSON.parse(currentUser)['campaignAccessDto'];
+    this.companyId = moduleAccessDto.companyId;
   }
 
   ngOnInit() {

--- a/src/app/partners/add-partners/add-partners.component.ts
+++ b/src/app/partners/add-partners/add-partners.component.ts
@@ -380,11 +380,11 @@ export class AddPartnersComponent implements OnInit, OnDestroy {
 
 		this.parentInput = {};
 		/*********XNFR-224*********/
-		const currentUser = localStorage.getItem('currentUser');
-		let campaginAccessDto = JSON.parse(currentUser)['campaignAccessDto'];
-		if (campaginAccessDto != undefined) {
-			this.companyId = campaginAccessDto.companyId;
-		}
+                const currentUser = localStorage.getItem('currentUser');
+                let moduleAccessDto = JSON.parse(currentUser)['moduleAccessDto'] || JSON.parse(currentUser)['campaignAccessDto'];
+                if (moduleAccessDto != undefined) {
+                        this.companyId = moduleAccessDto.companyId;
+                }
 		/*********XNFR-224*********/
 
 	}

--- a/src/app/util/form-analytics-util/form-analytics-util.component.ts
+++ b/src/app/util/form-analytics-util/form-analytics-util.component.ts
@@ -308,7 +308,7 @@ ngOnDestroy(){
         self.showLeadForm = true;
         self.selectedFormSubmitId = formDataRow.formSubmittedId;
         if(self.isOrgAdmin){
-            self.selectFormVendorCompanyId = self.authenticationService.user.campaignAccessDto.companyId;
+            self.selectFormVendorCompanyId = self.authenticationService.user.moduleAccessDto.companyId;
         }
         $("#addLeadsPopup"+this.modalPopupSuffix).modal("show");
         self.changeDetectorRef.detectChanges();


### PR DESCRIPTION
## Summary
- rename campaign access model and related DTOs to module access
- update services, guards, and components to use moduleAccessDto with backward compatibility mapping
- adjust references and imports across dashboard and company profile features

## Testing
- `npm run build` *(fails: ng not found)*
- `npm test -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c55d82743c8328b3b8a82ef4d2dd26